### PR TITLE
Add logic to only poll awake vehicles

### DIFF
--- a/teslajsonpy/controller.py
+++ b/teslajsonpy/controller.py
@@ -89,8 +89,8 @@ class Controller:
             if result is not None:
                 return result
             else:
-                _LOGGER.debug("Wrapper: f:%s, result:%s, args:%s, kwargs:%s, \
-                               inst:%s, vehicle_id:%s, _car_online:%s" %
+                _LOGGER.debug("Wrapper: f:%s, result:%s, args:%s, kwargs:%s, "
+                              "inst:%s, vehicle_id:%s, _car_online:%s" %
                               (f, result, args, kwargs, inst, vehicle_id,
                                inst._car_online))
                 while ('wake_if_asleep' in kwargs and kwargs['wake_if_asleep']
@@ -103,7 +103,7 @@ class Controller:
                     _LOGGER.debug("Result(%s): %s" % (retries, result))
                     if not result:
                         if retries < 5:
-                            time.sleep(sleep_delay)
+                            time.sleep(sleep_delay**(retries+2))
                             retries += 1
                             continue
                         else:

--- a/teslajsonpy/vehicle.py
+++ b/teslajsonpy/vehicle.py
@@ -16,7 +16,13 @@ class VehicleDevice:
             str(self._vin[3]).upper(), self._vin, self.type)
 
     def id(self):
-        return self._id 
+        return self._id
+
+    def assumed_state(self):
+        return (not self._controller._car_online[self.id()] and
+                (self._controller._last_update_time[self.id()] -
+                 self._controller._last_wake_up_time[self.id()] >
+                 self._controller.update_interval))
 
     @staticmethod
     def is_armable():


### PR DESCRIPTION
Should resolve #18. 

Also add an exponential growing delay counter for wake up retries. With 5 default retries, the delays should happen after 4, 8, 16, 32, 64 seconds with total time elapsed of 4, 12, 28, 60, and 124 seconds before failure. This may have to be dialed back as it could block commands while waiting for wakeup.