### PR TITLE
fix: remove checks for state for sentry mode

### DIFF
--- a/teslajsonpy/sentry_mode.py
+++ b/teslajsonpy/sentry_mode.py
@@ -44,21 +44,21 @@ class SentryModeSwitch(VehicleDevice):
         last_update = self._controller.get_last_update_time(self._id)
         if last_update >= self.__manual_update_time:
             data = self._controller.get_state_params(self._id)
-            self.__sentry_mode_available = data and data["sentry_mode_available"]
-            if self.__sentry_mode_available:
-                self.__sentry_mode = data["sentry_mode"]
+            if data and "sentry_mode_available" in data:
+                self.__sentry_mode_available = data["sentry_mode_available"]
+                if self.__sentry_mode_available and "sentry_mode" in data:
+                    self.__sentry_mode = data["sentry_mode"]
+            else:
+                self.__sentry_mode_available = False
+                self.__sentry_mode = False
 
-    def is_available(self):
+    def available(self):
         """Return whether the sentry mode is available."""
         return self.__sentry_mode_available
 
-    def is_enabled(self):
+    def is_on(self):
         """Return whether the sentry mode is enabled, always False if sentry mode is not available."""
         return self.__sentry_mode_available and self.__sentry_mode
-
-    def get_value(self):
-        """Return whether the sentry mode is enabled."""
-        return self.is_enabled()
 
     @staticmethod
     def has_battery():

--- a/teslajsonpy/sentry_mode.py
+++ b/teslajsonpy/sentry_mode.py
@@ -56,20 +56,18 @@ class SentryModeSwitch(VehicleDevice):
 
     async def enable_sentry_mode(self):
         """Enable the sentry mode."""
-        if not self.__sentry_mode:
-            data = await self._controller.command(
-                self._id, "set_sentry_mode", {"on": True}, wake_if_asleep=True
-            )
-            if data and data["response"]["result"]:
-                self.__sentry_mode = True
-            self.__manual_update_time = time.time()
+        data = await self._controller.command(
+            self._id, "set_sentry_mode", {"on": True}, wake_if_asleep=True
+        )
+        if data and data["response"]["result"]:
+            self.__sentry_mode = True
+        self.__manual_update_time = time.time()
 
     async def disable_sentry_mode(self):
         """Disable the sentry mode."""
-        if self.__sentry_mode:
-            data = await self._controller.command(
-                self._id, "set_sentry_mode", {"on": False}, wake_if_asleep=True
-            )
-            if data and data["response"]["result"]:
-                self.__sentry_mode = False
-            self.__manual_update_time = time.time()
+        data = await self._controller.command(
+            self._id, "set_sentry_mode", {"on": False}, wake_if_asleep=True
+        )
+        if data and data["response"]["result"]:
+            self.__sentry_mode = False
+        self.__manual_update_time = time.time()

--- a/teslajsonpy/sentry_mode.py
+++ b/teslajsonpy/sentry_mode.py
@@ -31,6 +31,7 @@ class SentryModeSwitch(VehicleDevice):
         """
         super().__init__(data, controller)
         self.__manual_update_time = 0
+        self.__sentry_mode_available = False
         self.__sentry_mode = False
         self.type = "sentry mode switch"
         self.hass_type = "switch"
@@ -43,11 +44,21 @@ class SentryModeSwitch(VehicleDevice):
         last_update = self._controller.get_last_update_time(self._id)
         if last_update >= self.__manual_update_time:
             data = self._controller.get_state_params(self._id)
-            self.__sentry_mode = data and data["sentry_mode"]
+            self.__sentry_mode_available = data and data["sentry_mode_available"]
+            if self.__sentry_mode_available:
+                self.__sentry_mode = data["sentry_mode"]
+
+    def is_available(self):
+        """Return whether the sentry mode is available."""
+        return self.__sentry_mode_available
+
+    def is_enabled(self):
+        """Return whether the sentry mode is enabled, always False if sentry mode is not available."""
+        return self.__sentry_mode_available and self.__sentry_mode
 
     def get_value(self):
         """Return whether the sentry mode is enabled."""
-        return self.__sentry_mode
+        return self.is_enabled()
 
     @staticmethod
     def has_battery():
@@ -56,18 +67,20 @@ class SentryModeSwitch(VehicleDevice):
 
     async def enable_sentry_mode(self):
         """Enable the sentry mode."""
-        data = await self._controller.command(
-            self._id, "set_sentry_mode", {"on": True}, wake_if_asleep=True
-        )
-        if data and data["response"]["result"]:
-            self.__sentry_mode = True
-        self.__manual_update_time = time.time()
+        if self.__sentry_mode_available and not self.__sentry_mode:
+            data = await self._controller.command(
+                self._id, "set_sentry_mode", {"on": True}, wake_if_asleep=True
+            )
+            if data and data["response"]["result"]:
+                self.__sentry_mode = True
+            self.__manual_update_time = time.time()
 
     async def disable_sentry_mode(self):
         """Disable the sentry mode."""
-        data = await self._controller.command(
-            self._id, "set_sentry_mode", {"on": False}, wake_if_asleep=True
-        )
-        if data and data["response"]["result"]:
-            self.__sentry_mode = False
-        self.__manual_update_time = time.time()
+        if self.__sentry_mode_available and self.__sentry_mode:
+            data = await self._controller.command(
+                self._id, "set_sentry_mode", {"on": False}, wake_if_asleep=True
+            )
+            if data and data["response"]["result"]:
+                self.__sentry_mode = False
+            self.__manual_update_time = time.time()

--- a/teslajsonpy/vehicle.py
+++ b/teslajsonpy/vehicle.py
@@ -40,6 +40,7 @@ class VehicleDevice:
         self._state = data["state"]
         self._car_type = f"Model {str(self._vin[3]).upper()}"
         self._car_version = ""
+        self._sentry_mode_available = False
         self._controller = controller
         self.should_poll = True
         self.type = "device"
@@ -84,6 +85,11 @@ class VehicleDevice:
         """Return the type of this Vehicle."""
         return self._car_type
 
+    @property
+    def sentry_mode_available(self):
+        """Return True if sentry mode is available on this Vehicle."""
+        return self._sentry_mode_available
+
     def assumed_state(self):
         # pylint: disable=protected-access
         """Return whether the data is from an online vehicle."""
@@ -94,11 +100,13 @@ class VehicleDevice:
         )
 
     async def async_update(self, wake_if_asleep=False):
-        """Update the car version."""
+        """Update the vehicle data."""
         await self._controller.update(self.id(), wake_if_asleep=wake_if_asleep)
         state = self._controller.get_state_params(self.id())
         if state and "car_version" in state:
             self._car_version = state["car_version"]
+        if state and "sentry_mode_available" in state:
+            self._sentry_mode_available = state["sentry_mode_available"]
 
     @staticmethod
     def is_armable():


### PR DESCRIPTION
Similar to PR #64, and as requested in PR #61, remove check for current state in case it is not accurate.