### PR TITLE
feat: separate library and home assistant implementation

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -15,3 +15,4 @@ reports=no
 
 [FORMAT]
 expected-line-ending-format=LF
+good-names=id,ex

--- a/teslajsonpy/ha/__init__.py
+++ b/teslajsonpy/ha/__init__.py
@@ -1,0 +1,1 @@
+"""Implementation of teslajsonpy for Home Assistant."""

--- a/teslajsonpy/ha/binary_sensor.py
+++ b/teslajsonpy/ha/binary_sensor.py
@@ -1,9 +1,42 @@
 #  SPDX-License-Identifier: Apache-2.0
 """
-Home Assistant binary sensor.
+Home Assistant binary sensors.
 """
 
+from enum import Enum
+
 from teslajsonpy.ha.entity import Entity
+
+
+class BinarySensorType(Enum):
+    """List of binary sensor types from Home Assistant.
+    
+    See also: https://developers.home-assistant.io/docs/entity_binary_sensor#available-device-classes
+    """
+
+    BATTERY = "battery"  # On means low Off means normal.
+    COLD = "cold"  # On means cold Off means normal.
+    CONNECTIVITY = "connectivity"  # On means connected Off means disconnected.
+    DOOR = "door"  # On means open Off means closed.
+    GARAGE_DOOR = "garage_door"  # On means open Off means closed.
+    GAS = "gas"  # On means gas detected Off means no gas (clear).
+    HEAT = "heat"  # On means hot Off means normal.
+    LIGHT = "light"  # On means light detected Off means no light.
+    LOCK = "lock"  # On means open (unlocked) Off means closed (locked).
+    MOISTURE = "moisture"  # On means wet Off means dry.
+    MOTION = "motion"  # On means motion detected Off means no motion (clear).
+    MOVING = "moving"  # On means moving Off means not moving (stopped).
+    OCCUPANCY = "occupancy"  # On means occupied Off means not occupied (clear).
+    OPENING = "opening"  # On means open Off means closed.
+    PLUG = "plug"  # On means plugged in Off means unplugged.
+    POWER = "power"  # On means power detected Off means no power.
+    PRESENCE = "presence"  # On means home Off means away.
+    PROBLEM = "problem"  # On means problem detected Off means no problem (OK).
+    SAFETY = "safety"  # On means unsafe Off means safe.
+    SMOKE = "smoke"  # On means smoke detected Off means no smoke (clear).
+    SOUND = "sound"  # On means sound detected Off means no sound (clear).
+    VIBRATION = "vibration"  # On means vibration detected Off means no vibration.
+    WINDOW = "window"  # On means open Off means closed.
 
 
 class BinarySensor(Entity):
@@ -29,6 +62,29 @@ class BinarySensor(Entity):
     def is_on(self) -> bool:
         """Return True if the binary sensor is currently on."""
         return self._is_on
+
+    def update(self) -> None:
+        """Fetch the latest state from the device and store it in the properties."""
+        raise NotImplementedError
+
+    async def async_update(self) -> None:
+        """Fetch asynchronously the latest state from the device and store it in the properties."""
+        raise NotImplementedError
+
+
+class ParkingSensor(BinarySensor):
+    """Tesla parking sensor for Home Assistant."""
+
+    def __init__(self):
+        """Initialize a the sensor.
+        
+        Parameters
+        ----------
+        device_class : str
+            The class of the device
+        """
+
+        super().__init__(BinarySensorType.POWER)
 
     def update(self) -> None:
         """Fetch the latest state from the device and store it in the properties."""

--- a/teslajsonpy/ha/binary_sensor.py
+++ b/teslajsonpy/ha/binary_sensor.py
@@ -2,6 +2,7 @@
 """Home Assistant binary sensors."""
 
 from enum import Enum
+from typing import Text
 
 from teslajsonpy.ha.entity import Entity
 
@@ -12,29 +13,29 @@ class BinarySensorType(Enum):
     See also: https://developers.home-assistant.io/docs/entity_binary_sensor#available-device-classes
     """
 
-    BATTERY = "battery"  # On means low Off means normal.
-    COLD = "cold"  # On means cold Off means normal.
-    CONNECTIVITY = "connectivity"  # On means connected Off means disconnected.
-    DOOR = "door"  # On means open Off means closed.
-    GARAGE_DOOR = "garage_door"  # On means open Off means closed.
-    GAS = "gas"  # On means gas detected Off means no gas (clear).
-    HEAT = "heat"  # On means hot Off means normal.
-    LIGHT = "light"  # On means light detected Off means no light.
-    LOCK = "lock"  # On means open (unlocked) Off means closed (locked).
-    MOISTURE = "moisture"  # On means wet Off means dry.
-    MOTION = "motion"  # On means motion detected Off means no motion (clear).
-    MOVING = "moving"  # On means moving Off means not moving (stopped).
-    OCCUPANCY = "occupancy"  # On means occupied Off means not occupied (clear).
-    OPENING = "opening"  # On means open Off means closed.
-    PLUG = "plug"  # On means plugged in Off means unplugged.
-    POWER = "power"  # On means power detected Off means no power.
-    PRESENCE = "presence"  # On means home Off means away.
-    PROBLEM = "problem"  # On means problem detected Off means no problem (OK).
-    SAFETY = "safety"  # On means unsafe Off means safe.
-    SMOKE = "smoke"  # On means smoke detected Off means no smoke (clear).
-    SOUND = "sound"  # On means sound detected Off means no sound (clear).
-    VIBRATION = "vibration"  # On means vibration detected Off means no vibration.
-    WINDOW = "window"  # On means open Off means closed.
+    BATTERY: Text = "battery"  # On means low Off means normal.
+    COLD: Text = "cold"  # On means cold Off means normal.
+    CONNECTIVITY: Text = "connectivity"  # On means connected Off means disconnected.
+    DOOR: Text = "door"  # On means open Off means closed.
+    GARAGE_DOOR: Text = "garage_door"  # On means open Off means closed.
+    GAS: Text = "gas"  # On means gas detected Off means no gas (clear).
+    HEAT: Text = "heat"  # On means hot Off means normal.
+    LIGHT: Text = "light"  # On means light detected Off means no light.
+    LOCK: Text = "lock"  # On means open (unlocked) Off means closed (locked).
+    MOISTURE: Text = "moisture"  # On means wet Off means dry.
+    MOTION: Text = "motion"  # On means motion detected Off means no motion (clear).
+    MOVING: Text = "moving"  # On means moving Off means not moving (stopped).
+    OCCUPANCY: Text = "occupancy"  # On means occupied Off means not occupied (clear).
+    OPENING: Text = "opening"  # On means open Off means closed.
+    PLUG: Text = "plug"  # On means plugged in Off means unplugged.
+    POWER: Text = "power"  # On means power detected Off means no power.
+    PRESENCE: Text = "presence"  # On means home Off means away.
+    PROBLEM: Text = "problem"  # On means problem detected Off means no problem (OK).
+    SAFETY: Text = "safety"  # On means unsafe Off means safe.
+    SMOKE: Text = "smoke"  # On means smoke detected Off means no smoke (clear).
+    SOUND: Text = "sound"  # On means sound detected Off means no sound (clear).
+    VIBRATION: Text = "vibration"  # On means vibration detected Off means no vibration.
+    WINDOW: Text = "window"  # On means open Off means closed.
 
 
 class BinarySensor(Entity):
@@ -43,12 +44,12 @@ class BinarySensor(Entity):
     See also: https://developers.home-assistant.io/docs/entity_binary_sensor
     """
 
-    def __init__(self, device_class: str):
+    def __init__(self, device_class: Text):
         """Initialize a binary sensor.
 
         Parameters
         ----------
-        device_class : str
+        device_class : Text
             The class of the device
 
         """
@@ -61,12 +62,8 @@ class BinarySensor(Entity):
         """Return True if the binary sensor is currently on."""
         return self._is_on
 
-    def update(self) -> None:
+    async def update(self) -> None:
         """Fetch the latest state from the device and store it in the properties."""
-        raise NotImplementedError
-
-    async def async_update(self) -> None:
-        """Fetch asynchronously the latest state from the device and store it in the properties."""
         raise NotImplementedError
 
 
@@ -74,23 +71,12 @@ class ChargerConnectionSensor(BinarySensor):
     """Tesla charger connection sensor for Home Assistant."""
 
     def __init__(self):
-        """Initialize the sensor.
-
-        Parameters
-        ----------
-        device_class : str
-            The class of the device
-
-        """
+        """Initialize the sensor."""
 
         super().__init__(BinarySensorType.CONNECTIVITY)
 
-    def update(self) -> None:
+    async def update(self) -> None:
         """Fetch the latest state from the device and store it in the properties."""
-        raise NotImplementedError
-
-    async def async_update(self) -> None:
-        """Fetch asynchronously the latest state from the device and store it in the properties."""
         raise NotImplementedError
 
 
@@ -98,23 +84,12 @@ class OnlineSensor(BinarySensor):
     """Tesla online sensor for Home Assistant."""
 
     def __init__(self):
-        """Initialize the sensor.
-
-        Parameters
-        ----------
-        device_class : str
-            The class of the device
-
-        """
+        """Initialize the sensor."""
 
         super().__init__(BinarySensorType.CONNECTIVITY)
 
-    def update(self) -> None:
+    async def update(self) -> None:
         """Fetch the latest state from the device and store it in the properties."""
-        raise NotImplementedError
-
-    async def async_update(self) -> None:
-        """Fetch asynchronously the latest state from the device and store it in the properties."""
         raise NotImplementedError
 
 
@@ -122,21 +97,10 @@ class ParkingSensor(BinarySensor):
     """Tesla parking sensor for Home Assistant."""
 
     def __init__(self):
-        """Initialize the sensor.
-
-        Parameters
-        ----------
-        device_class : str
-            The class of the device
-
-        """
+        """Initialize the sensor."""
 
         super().__init__(BinarySensorType.POWER)
 
-    def update(self) -> None:
+    async def update(self) -> None:
         """Fetch the latest state from the device and store it in the properties."""
-        raise NotImplementedError
-
-    async def async_update(self) -> None:
-        """Fetch asynchronously the latest state from the device and store it in the properties."""
         raise NotImplementedError

--- a/teslajsonpy/ha/binary_sensor.py
+++ b/teslajsonpy/ha/binary_sensor.py
@@ -70,11 +70,59 @@ class BinarySensor(Entity):
         raise NotImplementedError
 
 
+class ChargerConnectionSensor(BinarySensor):
+    """Tesla charger connection sensor for Home Assistant."""
+
+    def __init__(self):
+        """Initialize the sensor.
+
+        Parameters
+        ----------
+        device_class : str
+            The class of the device
+
+        """
+
+        super().__init__(BinarySensorType.CONNECTIVITY)
+
+    def update(self) -> None:
+        """Fetch the latest state from the device and store it in the properties."""
+        raise NotImplementedError
+
+    async def async_update(self) -> None:
+        """Fetch asynchronously the latest state from the device and store it in the properties."""
+        raise NotImplementedError
+
+
+class OnlineSensor(BinarySensor):
+    """Tesla online sensor for Home Assistant."""
+
+    def __init__(self):
+        """Initialize the sensor.
+
+        Parameters
+        ----------
+        device_class : str
+            The class of the device
+
+        """
+
+        super().__init__(BinarySensorType.CONNECTIVITY)
+
+    def update(self) -> None:
+        """Fetch the latest state from the device and store it in the properties."""
+        raise NotImplementedError
+
+    async def async_update(self) -> None:
+        """Fetch asynchronously the latest state from the device and store it in the properties."""
+        raise NotImplementedError
+
+
 class ParkingSensor(BinarySensor):
     """Tesla parking sensor for Home Assistant."""
 
     def __init__(self):
-        """Initialize a the sensor.
+        """Initialize the sensor.
 
         Parameters
         ----------

--- a/teslajsonpy/ha/binary_sensor.py
+++ b/teslajsonpy/ha/binary_sensor.py
@@ -1,0 +1,39 @@
+#  SPDX-License-Identifier: Apache-2.0
+"""
+Home Assistant binary sensor.
+"""
+
+from teslajsonpy.ha.entity import Entity
+
+
+class BinarySensor(Entity):
+    """
+    Wrapper for a Home Assistant binary sensor.
+    See also: https://developers.home-assistant.io/docs/entity_binary_sensor
+    """
+
+    def __init__(self, device_class: str):
+        """
+        Initialize a binary sensor.
+        
+        Parameters
+        ----------
+        device_class : str
+            The class of the device
+        """
+
+        super().__init__(device_class)
+        self._is_on = False
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if the binary sensor is currently on."""
+        return self._is_on
+
+    def update(self) -> None:
+        """Fetch the latest state from the device and store it in the properties."""
+        raise NotImplementedError
+
+    async def async_update(self) -> None:
+        """Fetch asynchronously the latest state from the device and store it in the properties."""
+        raise NotImplementedError

--- a/teslajsonpy/ha/binary_sensor.py
+++ b/teslajsonpy/ha/binary_sensor.py
@@ -1,7 +1,5 @@
 #  SPDX-License-Identifier: Apache-2.0
-"""
-Home Assistant binary sensors.
-"""
+"""Home Assistant binary sensors."""
 
 from enum import Enum
 
@@ -10,7 +8,7 @@ from teslajsonpy.ha.entity import Entity
 
 class BinarySensorType(Enum):
     """List of binary sensor types from Home Assistant.
-    
+
     See also: https://developers.home-assistant.io/docs/entity_binary_sensor#available-device-classes
     """
 
@@ -40,19 +38,19 @@ class BinarySensorType(Enum):
 
 
 class BinarySensor(Entity):
-    """
-    Wrapper for a Home Assistant binary sensor.
+    """Wrapper for a Home Assistant binary sensor.
+
     See also: https://developers.home-assistant.io/docs/entity_binary_sensor
     """
 
     def __init__(self, device_class: str):
-        """
-        Initialize a binary sensor.
-        
+        """Initialize a binary sensor.
+
         Parameters
         ----------
         device_class : str
             The class of the device
+
         """
 
         super().__init__(device_class)
@@ -77,11 +75,12 @@ class ParkingSensor(BinarySensor):
 
     def __init__(self):
         """Initialize a the sensor.
-        
+
         Parameters
         ----------
         device_class : str
             The class of the device
+
         """
 
         super().__init__(BinarySensorType.POWER)

--- a/teslajsonpy/ha/entity.py
+++ b/teslajsonpy/ha/entity.py
@@ -1,0 +1,99 @@
+#  SPDX-License-Identifier: Apache-2.0
+"""
+Home Assistant entity.
+"""
+
+
+class Entity:
+    """
+    Wrapper for a Home Assistant entity.
+    All Tesla entities shuld override this base class.
+    See also: https://developers.home-assistant.io/docs/entity_index
+    """
+
+    @property
+    def assumed_state(self):
+        """
+        Return True if the state is based on our assumption instead of reading it from the device.
+        """
+        return False
+
+    @property
+    def available(self):
+        """
+        Indicate if Home Assistant is able to read the state and control the underlying device.
+        """
+        return True
+
+    @property
+    def device_class(self):
+        """
+        Extra classification of what the device is. Each domain specifies their own. Device classes can come with extra requirements for unit of measurement and supported features.
+        """
+        return None
+
+    @property
+    def device_state_attributes(self):
+        """
+        Extra information to store in the state machine. It needs to be information that further explains the state, it should not be static information like firmware version. See below for details of standard attributes.
+        """
+        return None
+
+    @property
+    def entity_picture(self):
+        """
+        Url of a picture to show for the entity.
+        """
+        return None
+
+    @property
+    def name(self):
+        """
+        Name of the entity
+        """
+        return None
+
+    @property
+    def should_poll(self):
+        """
+        Should Home Assistant check with the entity for an updated state. If set to False, entity will need to notify Home Assistant of new updates by calling one of the schedule update methods.
+        """
+        return True
+
+    @property
+    def unique_id(self):
+        """
+        A unique identifier for this entity. Needs to be unique within a platform (ie light.hue). Should not be configurable by the user or be changeable. Learn more.
+        """
+        return None
+
+    @property
+    def force_update(self):
+        """
+        Write each update to the state machine, even if the data is the same.
+        Example use: when you are directly reading the value from a connected sensor instead of a cache.
+        Use with caution, will spam the state machine.
+        """
+        return False
+
+    @property
+    def icon(self):
+        """
+        Icon to use in the frontend.
+        Icons start with mdi: plus an identifier.
+        You probably don't need this since Home Assistant already provides default icons for all devices.
+        """
+        return None
+
+    @property
+    def entity_registry_enabled_default(self):
+        """Indicate if the entity should be enabled or disabled when it is first added to the entity registry."""
+        return True
+
+    def update(self) -> None:
+        """Fetch the latest state from the device and store it in the properties."""
+        raise NotImplementedError
+
+    async def async_update(self) -> None:
+        """Fetch asynchronously the latest state from the device and store it in the properties."""
+        raise NotImplementedError

--- a/teslajsonpy/ha/entity.py
+++ b/teslajsonpy/ha/entity.py
@@ -3,90 +3,100 @@
 Home Assistant entity.
 """
 
+from typing import Dict
+
 
 class Entity:
-    """
-    Wrapper for a Home Assistant entity.
+    """Wrapper for a Home Assistant entity.
+
     All Tesla entities shuld override this base class.
     See also: https://developers.home-assistant.io/docs/entity_index
     """
 
+    def __init__(self, device_class: str = None):
+        """
+        Initialize the entity.
+        
+        Parameters
+        ----------
+        device_class : str, optional
+            The class of the device
+        """
+        self._device_class = device_class
+
     @property
-    def assumed_state(self):
-        """
-        Return True if the state is based on our assumption instead of reading it from the device.
-        """
+    def assumed_state(self) -> bool:
+        """Return True if the state is based on our assumption instead of reading it from the device."""
         return False
 
     @property
-    def available(self):
+    def available(self) -> bool:
+        """Indicate if Home Assistant is able to read the state and control the underlying device."""
+        return True
+
+    @property
+    def device_class(self) -> str:
+        """Extra classification of what the device is. Each domain specifies their own.
+        
+        Device classes can come with extra requirements for unit of measurement and supported features.
         """
-        Indicate if Home Assistant is able to read the state and control the underlying device.
+        return self._device_class
+
+    @property
+    def device_state_attributes(self) -> Dict:
+        """Extra information to store in the state machine.
+        
+        It needs to be information that further explains the state, it should not be static information like firmware version.
+        """
+        return None
+
+    @property
+    def entity_picture(self) -> str:
+        """Url of a picture to show for the entity."""
+        return None
+
+    @property
+    def name(self) -> str:
+        """Name of the entity."""
+        return None
+
+    @property
+    def should_poll(self) -> bool:
+        """Should Home Assistant check with the entity for an updated state.
+        
+        If set to False, entity will need to notify Home Assistant of new updates by calling one of the schedule update methods.
         """
         return True
 
     @property
-    def device_class(self):
-        """
-        Extra classification of what the device is. Each domain specifies their own. Device classes can come with extra requirements for unit of measurement and supported features.
-        """
-        return None
-
-    @property
-    def device_state_attributes(self):
-        """
-        Extra information to store in the state machine. It needs to be information that further explains the state, it should not be static information like firmware version. See below for details of standard attributes.
+    def unique_id(self) -> str:
+        """A unique identifier for this entity.
+        
+        Needs to be unique within a platform (ie light.hue).
+        Should not be configurable by the user or be changeable.
         """
         return None
 
     @property
-    def entity_picture(self):
-        """
-        Url of a picture to show for the entity.
-        """
-        return None
-
-    @property
-    def name(self):
-        """
-        Name of the entity
-        """
-        return None
-
-    @property
-    def should_poll(self):
-        """
-        Should Home Assistant check with the entity for an updated state. If set to False, entity will need to notify Home Assistant of new updates by calling one of the schedule update methods.
-        """
-        return True
-
-    @property
-    def unique_id(self):
-        """
-        A unique identifier for this entity. Needs to be unique within a platform (ie light.hue). Should not be configurable by the user or be changeable. Learn more.
-        """
-        return None
-
-    @property
-    def force_update(self):
-        """
-        Write each update to the state machine, even if the data is the same.
+    def force_update(self) -> bool:
+        """Write each update to the state machine, even if the data is the same.
+        
         Example use: when you are directly reading the value from a connected sensor instead of a cache.
         Use with caution, will spam the state machine.
         """
         return False
 
     @property
-    def icon(self):
-        """
-        Icon to use in the frontend.
+    def icon(self) -> str:
+        """Icon to use in the frontend.
+        
         Icons start with mdi: plus an identifier.
         You probably don't need this since Home Assistant already provides default icons for all devices.
         """
         return None
 
     @property
-    def entity_registry_enabled_default(self):
+    def entity_registry_enabled_default(self) -> bool:
         """Indicate if the entity should be enabled or disabled when it is first added to the entity registry."""
         return True
 

--- a/teslajsonpy/ha/entity.py
+++ b/teslajsonpy/ha/entity.py
@@ -1,7 +1,5 @@
 #  SPDX-License-Identifier: Apache-2.0
-"""
-Home Assistant entity.
-"""
+"""Home Assistant entity."""
 
 from typing import Dict
 
@@ -14,13 +12,13 @@ class Entity:
     """
 
     def __init__(self, device_class: str = None):
-        """
-        Initialize the entity.
-        
+        """Initialize the entity.
+
         Parameters
         ----------
         device_class : str, optional
             The class of the device
+
         """
         self._device_class = device_class
 
@@ -31,56 +29,56 @@ class Entity:
 
     @property
     def available(self) -> bool:
-        """Indicate if Home Assistant is able to read the state and control the underlying device."""
+        """Indicate True if Home Assistant is able to read the state and control the underlying device."""
         return True
 
     @property
     def device_class(self) -> str:
-        """Extra classification of what the device is. Each domain specifies their own.
-        
+        """Return extra classification of what the device is. Each domain specifies their own.
+
         Device classes can come with extra requirements for unit of measurement and supported features.
         """
         return self._device_class
 
     @property
     def device_state_attributes(self) -> Dict:
-        """Extra information to store in the state machine.
-        
+        """Return extra information to store in the state machine.
+
         It needs to be information that further explains the state, it should not be static information like firmware version.
         """
         return None
 
     @property
     def entity_picture(self) -> str:
-        """Url of a picture to show for the entity."""
+        """Return the URL of a picture to show for the entity."""
         return None
 
     @property
     def name(self) -> str:
-        """Name of the entity."""
+        """Return the name of the entity."""
         return None
 
     @property
     def should_poll(self) -> bool:
-        """Should Home Assistant check with the entity for an updated state.
-        
+        """Tell Home Assistant if it must check with the entity for an updated state.
+
         If set to False, entity will need to notify Home Assistant of new updates by calling one of the schedule update methods.
         """
         return True
 
     @property
     def unique_id(self) -> str:
-        """A unique identifier for this entity.
-        
+        """Return the unique identifier for this entity.
+
         Needs to be unique within a platform (ie light.hue).
-        Should not be configurable by the user or be changeable.
+        It must not be configurable by the user or be changeable.
         """
         return None
 
     @property
     def force_update(self) -> bool:
         """Write each update to the state machine, even if the data is the same.
-        
+
         Example use: when you are directly reading the value from a connected sensor instead of a cache.
         Use with caution, will spam the state machine.
         """
@@ -88,8 +86,8 @@ class Entity:
 
     @property
     def icon(self) -> str:
-        """Icon to use in the frontend.
-        
+        """Return the icon to use in the frontend.
+
         Icons start with mdi: plus an identifier.
         You probably don't need this since Home Assistant already provides default icons for all devices.
         """

--- a/teslajsonpy/ha/entity.py
+++ b/teslajsonpy/ha/entity.py
@@ -1,7 +1,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 """Home Assistant entity."""
 
-from typing import Dict
+from typing import Dict, Text
 
 
 class Entity:
@@ -11,16 +11,16 @@ class Entity:
     See also: https://developers.home-assistant.io/docs/entity_index
     """
 
-    def __init__(self, device_class: str = None):
+    def __init__(self, device_class: Text = None):
         """Initialize the entity.
 
         Parameters
         ----------
-        device_class : str, optional
+        device_class : typing.Text, optional
             The class of the device
 
         """
-        self._device_class = device_class
+        self._device_class: Text = device_class
 
     @property
     def assumed_state(self) -> bool:
@@ -33,7 +33,7 @@ class Entity:
         return True
 
     @property
-    def device_class(self) -> str:
+    def device_class(self) -> Text:
         """Return extra classification of what the device is. Each domain specifies their own.
 
         Device classes can come with extra requirements for unit of measurement and supported features.
@@ -49,12 +49,12 @@ class Entity:
         return None
 
     @property
-    def entity_picture(self) -> str:
+    def entity_picture(self) -> Text:
         """Return the URL of a picture to show for the entity."""
         return None
 
     @property
-    def name(self) -> str:
+    def name(self) -> Text:
         """Return the name of the entity."""
         return None
 
@@ -67,7 +67,7 @@ class Entity:
         return True
 
     @property
-    def unique_id(self) -> str:
+    def unique_id(self) -> Text:
         """Return the unique identifier for this entity.
 
         Needs to be unique within a platform (ie light.hue).
@@ -85,7 +85,7 @@ class Entity:
         return False
 
     @property
-    def icon(self) -> str:
+    def icon(self) -> Text:
         """Return the icon to use in the frontend.
 
         Icons start with mdi: plus an identifier.
@@ -98,10 +98,6 @@ class Entity:
         """Indicate if the entity should be enabled or disabled when it is first added to the entity registry."""
         return True
 
-    def update(self) -> None:
+    async def update(self) -> None:
         """Fetch the latest state from the device and store it in the properties."""
-        raise NotImplementedError
-
-    async def async_update(self) -> None:
-        """Fetch asynchronously the latest state from the device and store it in the properties."""
         raise NotImplementedError

--- a/teslajsonpy/ha/lock.py
+++ b/teslajsonpy/ha/lock.py
@@ -1,0 +1,70 @@
+#  SPDX-License-Identifier: Apache-2.0
+"""Home Assistant locks."""
+
+from typing import Text
+
+from teslajsonpy.ha.entity import Entity
+
+
+class Lock(Entity):
+    """Wrapper for a Home Assistant lock.
+
+    See also: https://developers.home-assistant.io/docs/entity_lock
+    """
+
+    def __init__(self):
+        """Initialize a lock."""
+
+        super().__init__()
+        self._is_locked = False
+        self._changed_by = None
+
+    @property
+    def is_locked(self) -> bool:
+        """Return True if the lock is currently locked. Used to determine state."""
+        return self._is_locked
+
+    @property
+    def changed_by(self) -> Text:
+        """Describe what the last change was triggered by."""
+        return self._changed_by
+
+    async def lock(self) -> None:
+        """Lock the lock."""
+        raise NotImplementedError
+
+    async def unlock(self) -> None:
+        """Unlock the lock."""
+        raise NotImplementedError
+
+    async def open(self):
+        """Open (unlatch) the lock."""
+        raise NotImplementedError
+
+    async def update(self) -> None:
+        """Fetch the latest state from the device and store it in the properties."""
+        raise NotImplementedError
+
+
+class DoorLock(Lock):
+    """Tesla door lock for Home Assistant."""
+
+    async def update(self) -> None:
+        """Fetch the latest state from the device and store it in the properties."""
+        raise NotImplementedError
+
+
+class TrunkLock(Lock):
+    """Tesla trunk lock for Home Assistant."""
+
+    async def update(self) -> None:
+        """Fetch the latest state from the device and store it in the properties."""
+        raise NotImplementedError
+
+
+class FrunkLock(Lock):
+    """Tesla trunk lock for Home Assistant."""
+
+    async def update(self) -> None:
+        """Fetch the latest state from the device and store it in the properties."""
+        raise NotImplementedError

--- a/teslajsonpy/ha/lock.py
+++ b/teslajsonpy/ha/lock.py
@@ -55,7 +55,7 @@ class DoorLock(Lock):
 
 
 class TrunkLock(Lock):
-    """Tesla trunk lock for Home Assistant."""
+    """Tesla rear trunk lock for Home Assistant."""
 
     async def update(self) -> None:
         """Fetch the latest state from the device and store it in the properties."""
@@ -63,7 +63,7 @@ class TrunkLock(Lock):
 
 
 class FrunkLock(Lock):
-    """Tesla trunk lock for Home Assistant."""
+    """Tesla front trunk (frunk) lock for Home Assistant."""
 
     async def update(self) -> None:
         """Fetch the latest state from the device and store it in the properties."""

--- a/teslajsonpy/library/__init__.py
+++ b/teslajsonpy/library/__init__.py
@@ -1,0 +1,5 @@
+"""
+Tesla vehicle management library.
+
+This package provides the controller classes.
+"""

--- a/teslajsonpy/library/api.py
+++ b/teslajsonpy/library/api.py
@@ -1,0 +1,348 @@
+#  SPDX-License-Identifier: Apache-2.0
+"""Tesla API wrapper."""
+
+from typing import Dict, Text
+
+from teslajsonpy.library.connection import Connection
+
+from teslajsonpy.library.model.charge_state import ChargeStateModel
+from teslajsonpy.library.model.climate_state import ClimateStateModel
+from teslajsonpy.library.model.drive_state import DriveStateModel
+from teslajsonpy.library.model.gui_settings import GuiSettingsModel
+from teslajsonpy.library.model.token import TokenModel
+from teslajsonpy.library.model.vehicle_state import VehicleStateModel
+from teslajsonpy.library.model.vehicle_config import VehicleConfigModel
+
+
+class Api:  # pylint: disable-msg=R0904
+    """Tesla API wrapper.
+
+    This class provides a wrapper over the Tesla API.
+    See also: https://tesla-api.timdorr.com
+    """
+
+    @staticmethod
+    async def get_token(
+        connection: Connection, login: Text, password: Text
+    ) -> TokenModel:
+        """Get an access token for the given login/password."""
+
+        response = await Api.get_oauth_token(connection, login, password)
+
+        return (
+            TokenModel(
+                access_token=response["access_token"],
+                refresh_token=response["refresh_token"],
+                created_at=response["created_at"],
+                expires_in=response["expires_in"],
+                token_type=response["token_type"],
+            )
+            if response is not None
+            else None
+        )
+
+    @staticmethod
+    async def get_oauth_token(
+        connection: Connection, login: Text, password: Text
+    ) -> Dict:
+        """Get an access token.
+
+        POST /oauth/token
+        """
+        data = {
+            "grant_type": "password",
+            "client_id": "abc",
+            "client_secret": "123",
+            "email": login,
+            "password": password,
+        }
+
+        return await connection.post("/oauth/token", data)
+
+    @staticmethod
+    async def get_vehicles(connection: Connection) -> Dict:
+        """Retrieve a list of your owned vehicles (includes vehicles not yet shipped!).
+
+        GET /api/1/vehicles
+        """
+        return await connection.get("/api/1/vehicles")
+
+    @staticmethod
+    async def get_vehicle(connection: Connection, identifier) -> Dict:
+        """Return the vehicle identified by identifier.
+
+        GET /api/1/vehicles/{id}
+        """
+        return await connection.get(f"/api/1/vehicles/{identifier}")
+
+    @staticmethod
+    async def get_vehicle_data(connection: Connection, identifier) -> Dict:
+        """Return the vehicle identified by identifier.
+
+        GET /api/1/vehicles/{id}/vehicle_data
+        """
+        return await connection.get(f"/api/1/vehicles/{identifier}/vehicle_data")
+
+    @staticmethod
+    async def get_charge_state(connection: Connection, identifier) -> ChargeStateModel:
+        """Return the charge state of the vehicle identified by identifier.
+
+        GET /api/1/vehicles/{id}/data_request/charge_state
+        """
+        return await connection.get(
+            f"/api/1/vehicles/{identifier}/data_request/charge_state"
+        )
+
+    @staticmethod
+    async def get_climate_state(
+        connection: Connection, identifier
+    ) -> ClimateStateModel:
+        """Return the climate state of the vehicle identified by identifier.
+
+        GET /api/1/vehicles/{id}/data_request/climate_state
+        """
+        return await connection.get(
+            f"/api/1/vehicles/{identifier}/data_request/climate_state"
+        )
+
+    @staticmethod
+    async def get_drive_state(connection: Connection, identifier) -> DriveStateModel:
+        """Return the drive state of the vehicle identified by identifier.
+
+        GET /api/1/vehicles/{id}/data_request/drive_state
+        """
+        return await connection.get(
+            f"/api/1/vehicles/{identifier}/data_request/drive_state"
+        )
+
+    @staticmethod
+    async def get_gui_settings(connection: Connection, identifier) -> GuiSettingsModel:
+        """Return the GUI settings of the vehicle identified by identifier.
+
+        GET /api/1/vehicles/{id}/data_request/gui_settings
+        """
+        return await connection.get(
+            f"/api/1/vehicles/{identifier}/data_request/gui_settings"
+        )
+
+    @staticmethod
+    async def get_vehicle_state(
+        connection: Connection, identifier
+    ) -> VehicleStateModel:
+        """Return the vehicle state of the vehicle identified by identifier.
+
+        GET /api/1/vehicles/{id}/data_request/vehicle_state
+        """
+        return await connection.get(
+            f"/api/1/vehicles/{identifier}/data_request/vehicle_state"
+        )
+
+    @staticmethod
+    async def get_vehicle_config(
+        connection: Connection, identifier
+    ) -> VehicleConfigModel:
+        """Return the vehicle config of the vehicle identified by identifier.
+
+        GET /api/1/vehicles/{id}/data_request/vehicle_config
+        """
+        return await connection.get(
+            f"/api/1/vehicles/{identifier}/data_request/vehicle_config"
+        )
+
+    @staticmethod
+    async def wake_up(connection: Connection, identifier: Text) -> None:
+        """Wake up the vehicle identified by identifier.
+
+        POST /api/1/vehicles/{id}/wake_up
+        """
+        return await connection.post(f"/api/1/vehicles/{identifier}/wake_up")
+
+    @staticmethod
+    async def command_door_lock(connection: Connection, identifier: Text) -> None:
+        """Lock the doors of the vehicle identified by identifier.
+
+        POST /api/1/vehicles/{id}/command/door_lock
+        """
+        await Api.command(connection, identifier, "door_lock", None)
+
+    @staticmethod
+    async def command_door_unlock(connection: Connection, identifier: Text) -> None:
+        """Unlock the doors of the vehicle identified by identifier.
+
+        POST /api/1/vehicles/{id}/command/door_unlock
+        """
+        await Api.command(connection, identifier, "door_unlock", None)
+
+    @staticmethod
+    async def command_charge_port_door_open(
+        connection: Connection, identifier: Text
+    ) -> None:
+        """Open the charge port of the vehicle identified by identifier.
+
+        POST /api/1/vehicles/{id}/command/charge_port_door_open
+        """
+        await Api.command(connection, identifier, "charge_port_door_open", None)
+
+    @staticmethod
+    async def command_charge_port_door_close(
+        connection: Connection, identifier: Text
+    ) -> None:
+        """Close the charge port of the vehicle identified by identifier.
+
+        POST /api/1/vehicles/{id}/command/charge_port_door_close
+        """
+        await Api.command(connection, identifier, "charge_port_door_close", None)
+
+    @staticmethod
+    async def command_charge_start(connection: Connection, identifier: Text) -> None:
+        """Start the charge of the vehicle identified by identifier.
+
+        If the car is plugged in but not currently charging, this will start it charging.
+        POST /api/1/vehicles/{id}/command/charge_start
+        """
+        await Api.command(connection, identifier, "charge_start", None)
+
+    @staticmethod
+    async def command_charge_stop(connection: Connection, identifier: Text) -> None:
+        """Stop the charge of the vehicle identified by identifier.
+
+        If the car is currently charging, this will stop it.
+        POST /api/1/vehicles/{id}/command/charge_stop
+        """
+        await Api.command(connection, identifier, "charge_stop", None)
+
+    @staticmethod
+    async def command_charge_standard(connection: Connection, identifier: Text) -> None:
+        """Set the charge limit of the vehicle identified by identifier to "standard" or ~90%.
+
+        POST /api/1/vehicles/{id}/command/charge_standard
+        """
+        await Api.command(connection, identifier, "charge_standard", None)
+
+    @staticmethod
+    async def command_charge_max_range(
+        connection: Connection, identifier: Text
+    ) -> None:
+        """Set the charge limit of the vehicle identified by identifier to "max range" or 100%.
+
+        POST /api/1/vehicles/{id}/command/charge_max_range
+        """
+        await Api.command(connection, identifier, "charge_max_range", None)
+
+    @staticmethod
+    async def command_set_charge_limit(
+        connection: Connection, identifier: Text, limit: int = 90
+    ) -> None:
+        """Set the charge limit of the vehicle identified by identifier to the given value.
+
+        POST /api/1/vehicles/{id}/command/set_charge_limit
+        """
+        _percent = limit if limit in range(10, 100) else 90
+        await Api.command(
+            connection, identifier, "set_charge_limit", {"percent", _percent}
+        )
+
+    @staticmethod
+    async def command_auto_conditioning_start(
+        connection: Connection, identifier: Text
+    ) -> None:
+        """Start the climate control (HVAC) system of the vehicle identified by identifier.
+
+        This will cool or heat automatically, depending on set temperature.
+        POST /api/1/vehicles/{id}/command/auto_conditioning_start
+        """
+        await Api.command(connection, identifier, "auto_conditioning_start", None)
+
+    @staticmethod
+    async def command_auto_conditioning_stop(
+        connection: Connection, identifier: Text
+    ) -> None:
+        """Stop the climate control (HVAC) system of the vehicle identified by identifier.
+
+        POST /api/1/vehicles/{id}/command/auto_conditioning_stop
+        """
+        await Api.command(connection, identifier, "auto_conditioning_stop", None)
+
+    @staticmethod
+    async def command_set_temps(
+        connection: Connection, identifier, driver: int = 20, passenger: int = 20
+    ) -> None:
+        """Set the target temperature for the climate control (HVAC) system of the vehicle identified by identifier.
+
+        Note: The temperature in celsius, regardless of the region the car is in or the display settings of the car.
+        POST /api/1/vehicles/{id}/command/set_temps
+        """
+        await Api.command(
+            connection,
+            identifier,
+            "set_temps",
+            {"driver_temp": driver, "passenger_temp": passenger},
+        )
+
+    @staticmethod
+    async def command_set_sentry_mode_on(
+        connection: Connection, identifier: Text
+    ) -> None:
+        """Enable sentry mode on the vehicle identified by identifier.
+
+        POST /api/1/vehicles/{id}/command/set_sentry_mode
+        """
+        await Api.command(connection, identifier, "set_sentry_mode", {"on": True})
+
+    @staticmethod
+    async def command_set_sentry_mode_off(
+        connection: Connection, identifier: Text
+    ) -> None:
+        """Disable sentry mode on the vehicle identified by identifier.
+
+        POST /api/1/vehicles/{id}/command/set_sentry_mode
+        """
+        await Api.command(connection, identifier, "set_sentry_mode", {"on": False})
+
+    @staticmethod
+    async def command_actuate_trunk(connection: Connection, identifier: Text) -> None:
+        """Actuate the rear trunk of the vehicle identified by identifier.
+
+        POST /api/1/vehicles/{id}/command/actuate_trunk
+        """
+        await Api.command(
+            connection, identifier, "actuate_trunk", {"which_trunk": "rear"}
+        )
+
+    @staticmethod
+    async def command_actuate_frunk(connection: Connection, identifier: Text) -> None:
+        """Actuate the front trunk (frunk) of the vehicle identified by identifier.
+
+        POST /api/1/vehicles/{id}/command/actuate_trunk
+        """
+        await Api.command(
+            connection, identifier, "actuate_trunk", {"which_trunk": "front"}
+        )
+
+    @staticmethod
+    async def command_honk_horn(connection: Connection, identifier: Text) -> None:
+        """Honk the horn of the vehicle identified by identifier.
+
+        POST /api/1/vehicles/{id}/command/honk_horn
+        """
+        await Api.command(connection, identifier, "honk_horn", None)
+
+    @staticmethod
+    async def command_flash_lights(connection: Connection, identifier: Text) -> None:
+        """Flash the lights of the vehicle identified by identifier.
+
+        POST /api/1/vehicles/{id}/command/flash_lights
+        """
+        await Api.command(connection, identifier, "flash_lights", None)
+
+    @staticmethod
+    async def command(
+        connection: Connection, identifier: Text, command: Text, data=None
+    ) -> None:
+        """Execute a command on the vehicle identified by identifier.
+
+        POST /api/1/vehicles/{id}/command/{command}
+        """
+        return await connection.post(
+            f"/api/1/vehicles/{identifier}/command/{command}", data
+        )

--- a/teslajsonpy/library/connection.py
+++ b/teslajsonpy/library/connection.py
@@ -1,0 +1,20 @@
+#  SPDX-License-Identifier: Apache-2.0
+"""Connection utilities."""
+
+from typing import Dict, Text
+
+
+class Connection:
+    """The connection used to post data to the Tesla API."""
+
+    async def get(self, endpoint: Text) -> Dict:
+        """Get data from API."""
+        return await self.request(endpoint, "get")
+
+    async def post(self, endpoint: Text, data: Dict = None) -> Dict:
+        """Get data from API."""
+        return await self.request(endpoint, "post", data)
+
+    async def request(self, endpoint: Text, method: Text, data: Dict = None) -> Dict:
+        """Make a HTTP request to API."""
+        raise NotImplementedError

--- a/teslajsonpy/library/controller.py
+++ b/teslajsonpy/library/controller.py
@@ -1,0 +1,238 @@
+#  SPDX-License-Identifier: Apache-2.0
+"""Tesla controller."""
+
+from typing import Dict, Text, Tuple
+
+from teslajsonpy.library.api import Api
+from teslajsonpy.library.connection import Connection
+from teslajsonpy.library.exceptions import UnknownVehicleException
+
+from teslajsonpy.library.model.vehicle import VehicleModel
+from teslajsonpy.library.model.token import TokenModel
+
+
+class Controller:  # pylint: disable-msg=R0904
+    """Tesla controller."""
+
+    def __init__(self):
+        """Initialize the controller."""
+
+        self.__connection: Connection = Connection()
+        self.__token: TokenModel = None
+        self._vehicles: Dict[Text, VehicleModel] = {}
+
+    async def connect(self, login: Text, password: Text) -> Connection:
+        """Connect to the Tesla servers, using the login/password combination."""
+
+        self.__token = await Api.get_token(self.__connection, login, password)
+        return self.__connection
+
+    def get_tokens(self) -> Tuple[Text, Text]:
+        """Return refresh and access tokens.
+
+        Returns
+            Tuple[Text, Text]: Returns a tuple of refresh and access tokens
+
+        """
+        return (
+            (self.__token.refresh_token, self.__token.access_token)
+            if self.__token is not None
+            else None
+        )
+
+    def get_expiration(self) -> int:
+        """Get the current session expiration."""
+        return self.__token.expires_in
+
+    @property
+    def vehicles(self) -> Dict[Text, VehicleModel]:
+        """Retrieve the vehicle map [id, vehicle model]."""
+        return self._vehicles
+
+    def get_vehicle(self, identifier: Text) -> VehicleModel:
+        """Retrieve the cached vehicle identified by identifier."""
+        return self._vehicles[identifier] if identifier in self._vehicles else None
+
+    def add_vehicle(self, vehicle: VehicleModel) -> VehicleModel:
+        """Add a vehicle to the controller's list of vehicles."""
+        if vehicle is not None and vehicle.id is not None:
+            existing_vehicle = self.get_vehicle(vehicle.id)
+
+            if existing_vehicle is None:
+                self._vehicles[vehicle.id] = vehicle
+                return vehicle
+
+            return existing_vehicle
+
+        return None
+
+    async def refresh_vehicles(self) -> None:
+        """Retrieve the list of your owned vehicles from the tesla servers (includes vehicles not yet shipped!).
+
+        The list of vehicles is cleared and updated with all available vehicles fetched from the Tesla API.
+        """
+
+        self._vehicles.clear()
+
+        result = await Api.get_vehicles(self.__connection)
+        vehicles = result["response"] if "response" in result else None
+
+        if vehicles is not None:
+            for vehicle in vehicles:
+                if vehicle["id"] is not None:
+                    await self._fetch_vehicle_data(vehicle["id"])
+
+    async def _fetch_vehicle_data(self, identifier: Text) -> None:
+        """Fetch the vehicle data identified by identifier from the tesla servers.
+
+        Read the vehicle data and add it to the list of vehicles.
+        """
+
+        result = await Api.get_vehicle_data(self.__connection, identifier)
+        vehicle_data = result["response"] if "response" in result else None
+
+        vehicle = VehicleModel()
+        vehicle.load(vehicle_data)
+        self.add_vehicle(vehicle)
+
+    async def lock_doors(self, identifier: Text) -> None:
+        """Lock the doors of the vehicle identified by identifier."""
+        if self.get_vehicle(identifier) is None:
+            raise UnknownVehicleException
+
+        await Api.command_door_lock(self.__connection, identifier)
+
+    async def unlock_doors(self, identifier: Text) -> None:
+        """Unlock the doors of the vehicle identified by identifier."""
+        if self.get_vehicle(identifier) is None:
+            raise UnknownVehicleException
+
+        await Api.command_door_unlock(self.__connection, identifier)
+
+    async def open_charge_port(self, identifier: Text) -> None:
+        """Open the charge port of the vehicle identified by identifier."""
+        if self.get_vehicle(identifier) is None:
+            raise UnknownVehicleException
+
+        await Api.command_charge_port_door_open(self.__connection, identifier)
+
+    async def close_charge_port(self, identifier: Text) -> None:
+        """Close the charge port of the vehicle identified by identifier."""
+        if self.get_vehicle(identifier) is None:
+            raise UnknownVehicleException
+
+        await Api.command_charge_port_door_close(self.__connection, identifier)
+
+    async def start_charge(self, identifier: Text) -> None:
+        """Start the charge of the vehicle identified by identifier.
+
+        If the car is plugged in but not currently charging, this will start it charging.
+        """
+        if self.get_vehicle(identifier) is None:
+            raise UnknownVehicleException
+
+        await Api.command_charge_start(self.__connection, identifier)
+
+    async def stop_charge(self, identifier: Text) -> None:
+        """Stop the charge of the vehicle identified by identifier.
+
+        If the car is currently charging, this will stop it.
+        """
+        if self.get_vehicle(identifier) is None:
+            raise UnknownVehicleException
+
+        await Api.command_charge_stop(self.__connection, identifier)
+
+    async def set_charge_limit_standard(self, identifier: Text) -> None:
+        """Set the charge limit of the vehicle identified by identifier to "standard" or ~90%."""
+        if self.get_vehicle(identifier) is None:
+            raise UnknownVehicleException
+
+        await Api.command_charge_standard(self.__connection, identifier)
+
+    async def set_charge_limit_max_range(self, identifier: Text) -> None:
+        """Set the charge limit of the vehicle identified by identifier to "max range" or 100%."""
+        if self.get_vehicle(identifier) is None:
+            raise UnknownVehicleException
+
+        await Api.command_charge_max_range(self.__connection, identifier)
+
+    async def set_charge_limit(self, identifier: Text, limit: int = 90) -> None:
+        """Set the charge limit of the vehicle identified by identifier to the given value."""
+        if self.get_vehicle(identifier) is None:
+            raise UnknownVehicleException
+
+        await Api.command_set_charge_limit(self.__connection, identifier, limit)
+
+    async def start_climate(self, identifier: Text) -> None:
+        """Start the climate control (HVAC) system of the vehicle identified by identifier.
+
+        This will cool or heat automatically, depending on set temperature.
+        """
+        if self.get_vehicle(identifier) is None:
+            raise UnknownVehicleException
+
+        await Api.command_auto_conditioning_start(self.__connection, identifier)
+
+    async def stop_climate(self, identifier: Text) -> None:
+        """Stop the climate control (HVAC) system of the vehicle identified by identifier."""
+        if self.get_vehicle(identifier) is None:
+            raise UnknownVehicleException
+
+        await Api.command_auto_conditioning_stop(self.__connection, identifier)
+
+    async def set_climate_temperature(
+        self, identifier: Text, temperature: int = 20
+    ) -> None:
+        """Set the target temperature for the climate control (HVAC) system of the vehicle identified by identifier.
+
+        Note: The temperature in celsius, regardless of the region the car is in or the display settings of the car.
+        """
+        if self.get_vehicle(identifier) is None:
+            raise UnknownVehicleException
+
+        await Api.command_set_temps(
+            self.__connection, identifier, temperature, temperature
+        )
+
+    async def enable_sentry_mode(self, identifier: Text) -> None:
+        """Enable sentry mode on the vehicle identified by identifier."""
+        if self.get_vehicle(identifier) is None:
+            raise UnknownVehicleException
+
+        await Api.command_set_sentry_mode_on(self.__connection, identifier)
+
+    async def disable_sentry_mode(self, identifier: Text) -> None:
+        """Disable sentry mode on the vehicle identified by identifier."""
+        if self.get_vehicle(identifier) is None:
+            raise UnknownVehicleException
+
+        await Api.command_set_sentry_mode_off(self.__connection, identifier)
+
+    async def actuate_trunk(self, identifier: Text) -> None:
+        """Actuate the rear trunk of the vehicle identified by identifier."""
+        if self.get_vehicle(identifier) is None:
+            raise UnknownVehicleException
+
+        await Api.command_actuate_trunk(self.__connection, identifier)
+
+    async def actuate_frunk(self, identifier: Text) -> None:
+        """Actuate the front trunk (frunk) of the vehicle identified by identifier."""
+        if self.get_vehicle(identifier) is None:
+            raise UnknownVehicleException
+
+        await Api.command_actuate_frunk(self.__connection, identifier)
+
+    async def honk_horn(self, identifier: Text) -> None:
+        """Honk the horn of the vehicle identified by identifier."""
+        if self.get_vehicle(identifier) is None:
+            raise UnknownVehicleException
+
+        await Api.command_honk_horn(self.__connection, identifier)
+
+    async def flash_lights(self, identifier: Text) -> None:
+        """Flash the lights of the vehicle identified by identifier."""
+        if self.get_vehicle(identifier) is None:
+            raise UnknownVehicleException
+
+        await Api.command_flash_lights(self.__connection, identifier)

--- a/teslajsonpy/library/exceptions.py
+++ b/teslajsonpy/library/exceptions.py
@@ -1,0 +1,8 @@
+#  SPDX-License-Identifier: Apache-2.0
+"""Exception utilities."""
+
+
+class UnknownVehicleException(Exception):
+    """Exception thrown when an unknown vehicle is request."""
+
+    pass

--- a/teslajsonpy/library/model/__init__.py
+++ b/teslajsonpy/library/model/__init__.py
@@ -1,0 +1,5 @@
+"""
+Tesla vehicle management library.
+
+This package provides the model classes.
+"""

--- a/teslajsonpy/library/model/charge_state.py
+++ b/teslajsonpy/library/model/charge_state.py
@@ -1,0 +1,274 @@
+#  SPDX-License-Identifier: Apache-2.0
+"""Tesla vehicle charge state model."""
+
+from typing import Text
+
+
+class ChargeStateModel:  # pylint: disable-msg=R0904
+    """Tesla vehicle charge state model.
+
+    The model is represented by the charge state API results.
+    See also: https://tesla-api.timdorr.com/vehicle/state/chargestate
+    """
+
+    def __init__(self):
+        """Initialize the charge state model."""
+
+        self.__battery_heater_on = None
+        self.__battery_level = None
+        self.__battery_range = None
+        self.__charge_current_request = None
+        self.__charge_current_request_max = None
+        self.__charge_enable_request = None
+        self.__charge_energy_added = None
+        self.__charge_limit_soc = None
+        self.__charge_limit_soc_max = None
+        self.__charge_limit_soc_min = None
+        self.__charge_limit_soc_std = None
+        self.__charge_miles_added_ideal = None
+        self.__charge_miles_added_rated = None
+        self.__charge_port_cold_weather_mode = None
+        self.__charge_port_door_open = None
+        self.__charge_port_latch = None
+        self.__charge_rate = None
+        self.__charge_to_max_range = None
+        self.__charger_actual_current = None
+        self.__charger_phases = None
+        self.__charger_pilot_current = None
+        self.__charger_power = None
+        self.__charger_voltage = None
+        self.__charging_state = None
+        self.__conn_charge_cable = None
+        self.__est_battery_range = None
+        self.__fast_charger_brand = None
+        self.__fast_charger_present = None
+        self.__fast_charger_type = None
+        self.__ideal_battery_range = None
+        self.__managed_charging_active = None
+        self.__managed_charging_start_time = None
+        self.__managed_charging_user_canceled = None
+        self.__max_range_charge_counter = None
+        self.__minutes_to_full_charge = None
+        self.__not_enough_power_to_heat = None
+        self.__scheduled_charging_pending = None
+        self.__scheduled_charging_start_time = None
+        self.__time_to_full_charge = None
+        self.__timestamp = None
+        self.__trip_charging = None
+        self.__usable_battery_level = None
+        self.__user_charge_enable_request = None
+
+    @property
+    def battery_heater_on(self) -> bool:
+        """Return the battery_heater_on."""
+        return self.__battery_heater_on
+
+    @property
+    def battery_level(self) -> int:
+        """Return the battery_level."""
+        return self.__battery_level
+
+    @property
+    def battery_range(self) -> float:
+        """Return the battery_range."""
+        return self.__battery_range
+
+    @property
+    def charge_current_request(self) -> int:
+        """Return the charge_current_request."""
+        return self.__charge_current_request
+
+    @property
+    def charge_current_request_max(self) -> int:
+        """Return the charge_current_request_max."""
+        return self.__charge_current_request_max
+
+    @property
+    def charge_enable_request(self) -> bool:
+        """Return the charge_enable_request."""
+        return self.__charge_enable_request
+
+    @property
+    def charge_energy_added(self) -> float:
+        """Return the charge_energy_added."""
+        return self.__charge_energy_added
+
+    @property
+    def charge_limit_soc(self) -> int:
+        """Return the charge_limit_soc."""
+        return self.__charge_limit_soc
+
+    @property
+    def charge_limit_soc_max(self) -> int:
+        """Return the charge_limit_soc_max."""
+        return self.__charge_limit_soc_max
+
+    @property
+    def charge_limit_soc_min(self) -> int:
+        """Return the charge_limit_soc_min."""
+        return self.__charge_limit_soc_min
+
+    @property
+    def charge_limit_soc_std(self) -> int:
+        """Return the charge_limit_soc_std."""
+        return self.__charge_limit_soc_std
+
+    @property
+    def charge_miles_added_ideal(self) -> float:
+        """Return the charge_miles_added_ideal."""
+        return self.__charge_miles_added_ideal
+
+    @property
+    def charge_miles_added_rated(self) -> float:
+        """Return the charge_miles_added_rated."""
+        return self.__charge_miles_added_rated
+
+    @property
+    def charge_port_cold_weather_mode(self) -> bool:
+        """Return the charge_port_cold_weather_mode."""
+        return self.__charge_port_cold_weather_mode
+
+    @property
+    def charge_port_door_open(self) -> bool:
+        """Return the charge_port_door_open."""
+        return self.__charge_port_door_open
+
+    @property
+    def charge_port_latch(self) -> Text:
+        """Return the charge_port_latch."""
+        return self.__charge_port_latch
+
+    @property
+    def charge_rate(self) -> float:
+        """Return the charge_rate."""
+        return self.__charge_rate
+
+    @property
+    def charge_to_max_range(self) -> bool:
+        """Return the charge_to_max_range."""
+        return self.__charge_to_max_range
+
+    @property
+    def charger_actual_current(self) -> int:
+        """Return the charger_actual_current."""
+        return self.__charger_actual_current
+
+    @property
+    def charger_phases(self):
+        """Return the charger_phases."""
+        return self.__charger_phases
+
+    @property
+    def charger_pilot_current(self) -> int:
+        """Return the charger_pilot_current."""
+        return self.__charger_pilot_current
+
+    @property
+    def charger_power(self) -> int:
+        """Return the charger_power."""
+        return self.__charger_power
+
+    @property
+    def charger_voltage(self) -> int:
+        """Return the charger_voltage."""
+        return self.__charger_voltage
+
+    @property
+    def charging_state(self) -> Text:
+        """Return the charging_state."""
+        return self.__charging_state
+
+    @property
+    def conn_charge_cable(self) -> Text:
+        """Return the conn_charge_cable."""
+        return self.__conn_charge_cable
+
+    @property
+    def est_battery_range(self) -> float:
+        """Return the est_battery_range."""
+        return self.__est_battery_range
+
+    @property
+    def fast_charger_brand(self) -> Text:
+        """Return the fast_charger_brand."""
+        return self.__fast_charger_brand
+
+    @property
+    def fast_charger_present(self) -> float:
+        """Return the fast_charger_present."""
+        return self.__fast_charger_present
+
+    @property
+    def fast_charger_type(self) -> Text:
+        """Return the fast_charger_type."""
+        return self.__fast_charger_type
+
+    @property
+    def ideal_battery_range(self) -> float:
+        """Return the ideal_battery_range."""
+        return self.__ideal_battery_range
+
+    @property
+    def managed_charging_active(self) -> bool:
+        """Return the managed_charging_active."""
+        return self.__managed_charging_active
+
+    @property
+    def managed_charging_start_time(self):
+        """Return the managed_charging_start_time."""
+        return self.__managed_charging_start_time
+
+    @property
+    def managed_charging_user_canceled(self) -> bool:
+        """Return the managed_charging_user_canceled."""
+        return self.__managed_charging_user_canceled
+
+    @property
+    def max_range_charge_counter(self) -> int:
+        """Return the max_range_charge_counter."""
+        return self.__max_range_charge_counter
+
+    @property
+    def minutes_to_full_charge(self) -> int:
+        """Return the minutes_to_full_charge."""
+        return self.__minutes_to_full_charge
+
+    @property
+    def not_enough_power_to_heat(self) -> bool:
+        """Return the not_enough_power_to_heat."""
+        return self.__not_enough_power_to_heat
+
+    @property
+    def scheduled_charging_pending(self) -> bool:
+        """Return the scheduled_charging_pending."""
+        return self.__scheduled_charging_pending
+
+    @property
+    def scheduled_charging_start_time(self):
+        """Return the scheduled_charging_start_time."""
+        return self.__scheduled_charging_start_time
+
+    @property
+    def time_to_full_charge(self) -> float:
+        """Return the time_to_full_charge."""
+        return self.__time_to_full_charge
+
+    @property
+    def timestamp(self) -> int:
+        """Return the timestamp."""
+        return self.__timestamp
+
+    @property
+    def trip_charging(self) -> bool:
+        """Return the trip_charging."""
+        return self.__trip_charging
+
+    @property
+    def usable_battery_level(self) -> int:
+        """Return the usable_battery_level."""
+        return self.__usable_battery_level
+
+    @property
+    def user_charge_enable_request(self):
+        """Return the user_charge_enable_request."""
+        return self.__user_charge_enable_request

--- a/teslajsonpy/library/model/charge_state.py
+++ b/teslajsonpy/library/model/charge_state.py
@@ -1,7 +1,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 """Tesla vehicle charge state model."""
 
-from typing import Text
+from typing import Dict, Text
 
 
 class ChargeStateModel:  # pylint: disable-msg=R0904
@@ -57,6 +57,159 @@ class ChargeStateModel:  # pylint: disable-msg=R0904
         self.__trip_charging = None
         self.__usable_battery_level = None
         self.__user_charge_enable_request = None
+
+    def load(self, data: Dict) -> None:
+        """Load data from a JSON result."""
+
+        self.__battery_heater_on = (
+            data["battery_heater_on"] if "battery_heater_on" in data else None
+        )
+        self.__battery_level = (
+            data["battery_level"] if "battery_level" in data else None
+        )
+        self.__battery_range = (
+            data["battery_range"] if "battery_range" in data else None
+        )
+        self.__charge_current_request = (
+            data["charge_current_request"] if "charge_current_request" in data else None
+        )
+        self.__charge_current_request_max = (
+            data["charge_current_request_max"]
+            if "charge_current_request_max" in data
+            else None
+        )
+        self.__charge_enable_request = (
+            data["charge_enable_request"] if "charge_enable_request" in data else None
+        )
+        self.__charge_energy_added = (
+            data["charge_energy_added"] if "charge_energy_added" in data else None
+        )
+        self.__charge_limit_soc = (
+            data["charge_limit_soc"] if "charge_limit_soc" in data else None
+        )
+        self.__charge_limit_soc_max = (
+            data["charge_limit_soc_max"] if "charge_limit_soc_max" in data else None
+        )
+        self.__charge_limit_soc_min = (
+            data["charge_limit_soc_min"] if "charge_limit_soc_min" in data else None
+        )
+        self.__charge_limit_soc_std = (
+            data["charge_limit_soc_std"] if "charge_limit_soc_std" in data else None
+        )
+        self.__charge_miles_added_ideal = (
+            data["charge_miles_added_ideal"]
+            if "charge_miles_added_ideal" in data
+            else None
+        )
+        self.__charge_miles_added_rated = (
+            data["charge_miles_added_rated"]
+            if "charge_miles_added_rated" in data
+            else None
+        )
+        self.__charge_port_cold_weather_mode = (
+            data["charge_port_cold_weather_mode"]
+            if "charge_port_cold_weather_mode" in data
+            else None
+        )
+        self.__charge_port_door_open = (
+            data["charge_port_door_open"] if "charge_port_door_open" in data else None
+        )
+        self.__charge_port_latch = (
+            data["charge_port_latch"] if "charge_port_latch" in data else None
+        )
+        self.__charge_rate = data["charge_rate"] if "charge_rate" in data else None
+        self.__charge_to_max_range = (
+            data["charge_to_max_range"] if "charge_to_max_range" in data else None
+        )
+        self.__charger_actual_current = (
+            data["charger_actual_current"] if "charger_actual_current" in data else None
+        )
+        self.__charger_phases = (
+            data["charger_phases"] if "charger_phases" in data else None
+        )
+        self.__charger_pilot_current = (
+            data["charger_pilot_current"] if "charger_pilot_current" in data else None
+        )
+        self.__charger_power = (
+            data["charger_power"] if "charger_power" in data else None
+        )
+        self.__charger_voltage = (
+            data["charger_voltage"] if "charger_voltage" in data else None
+        )
+        self.__charging_state = (
+            data["charging_state"] if "charging_state" in data else None
+        )
+        self.__conn_charge_cable = (
+            data["conn_charge_cable"] if "conn_charge_cable" in data else None
+        )
+        self.__est_battery_range = (
+            data["est_battery_range"] if "est_battery_range" in data else None
+        )
+        self.__fast_charger_brand = (
+            data["fast_charger_brand"] if "fast_charger_brand" in data else None
+        )
+        self.__fast_charger_present = (
+            data["fast_charger_present"] if "fast_charger_present" in data else None
+        )
+        self.__fast_charger_type = (
+            data["fast_charger_type"] if "fast_charger_type" in data else None
+        )
+        self.__ideal_battery_range = (
+            data["ideal_battery_range"] if "ideal_battery_range" in data else None
+        )
+        self.__managed_charging_active = (
+            data["managed_charging_active"]
+            if "managed_charging_active" in data
+            else None
+        )
+        self.__managed_charging_start_time = (
+            data["managed_charging_start_time"]
+            if "managed_charging_start_time" in data
+            else None
+        )
+        self.__managed_charging_user_canceled = (
+            data["managed_charging_user_canceled"]
+            if "managed_charging_user_canceled" in data
+            else None
+        )
+        self.__max_range_charge_counter = (
+            data["max_range_charge_counter"]
+            if "max_range_charge_counter" in data
+            else None
+        )
+        self.__minutes_to_full_charge = (
+            data["minutes_to_full_charge"] if "minutes_to_full_charge" in data else None
+        )
+        self.__not_enough_power_to_heat = (
+            data["not_enough_power_to_heat"]
+            if "not_enough_power_to_heat" in data
+            else None
+        )
+        self.__scheduled_charging_pending = (
+            data["scheduled_charging_pending"]
+            if "scheduled_charging_pending" in data
+            else None
+        )
+        self.__scheduled_charging_start_time = (
+            data["scheduled_charging_start_time"]
+            if "scheduled_charging_start_time" in data
+            else None
+        )
+        self.__time_to_full_charge = (
+            data["time_to_full_charge"] if "time_to_full_charge" in data else None
+        )
+        self.__timestamp = data["timestamp"] if "timestamp" in data else None
+        self.__trip_charging = (
+            data["trip_charging"] if "trip_charging" in data else None
+        )
+        self.__usable_battery_level = (
+            data["usable_battery_level"] if "usable_battery_level" in data else None
+        )
+        self.__user_charge_enable_request = (
+            data["user_charge_enable_request"]
+            if "user_charge_enable_request" in data
+            else None
+        )
 
     @property
     def battery_heater_on(self) -> bool:

--- a/teslajsonpy/library/model/climate_state.py
+++ b/teslajsonpy/library/model/climate_state.py
@@ -1,7 +1,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 """Tesla vehicle climate state model."""
 
-from typing import Text
+from typing import Dict, Text
 
 
 class ClimateStateModel:  # pylint: disable-msg=R0904
@@ -44,6 +44,102 @@ class ClimateStateModel:  # pylint: disable-msg=R0904
         self.__steering_wheel_heater = None
         self.__timestamp = None
         self.__wiper_blade_heater = None
+
+    def load(self, data: Dict) -> None:
+        """Load data from a JSON result."""
+
+        self.__battery_heater = (
+            data["battery_heater"] if "battery_heater" in data else None
+        )
+        self.__battery_heater_no_power = (
+            data["battery_heater_no_power"]
+            if "battery_heater_no_power" in data
+            else None
+        )
+        self.__climate_keeper_mode = (
+            data["climate_keeper_mode"] if "climate_keeper_mode" in data else None
+        )
+        self.__defrost_mode = data["defrost_mode"] if "defrost_mode" in data else None
+        self.__driver_temp_setting = (
+            data["driver_temp_setting"] if "driver_temp_setting" in data else None
+        )
+        self.__fan_status = data["fan_status"] if "fan_status" in data else None
+        self.__inside_temp = data["inside_temp"] if "inside_temp" in data else None
+        self.__is_auto_conditioning_on = (
+            data["is_auto_conditioning_on"]
+            if "is_auto_conditioning_on" in data
+            else None
+        )
+        self.__is_climate_on = (
+            data["is_climate_on"] if "is_climate_on" in data else None
+        )
+        self.__is_front_defroster_on = (
+            data["is_front_defroster_on"] if "is_front_defroster_on" in data else None
+        )
+        self.__is_preconditioning = (
+            data["is_preconditioning"] if "is_preconditioning" in data else None
+        )
+        self.__is_rear_defroster_on = (
+            data["is_rear_defroster_on"] if "is_rear_defroster_on" in data else None
+        )
+        self.__left_temp_direction = (
+            data["left_temp_direction"] if "left_temp_direction" in data else None
+        )
+        self.__max_avail_temp = (
+            data["max_avail_temp"] if "max_avail_temp" in data else None
+        )
+        self.__min_avail_temp = (
+            data["min_avail_temp"] if "min_avail_temp" in data else None
+        )
+        self.__outside_temp = data["outside_temp"] if "outside_temp" in data else None
+        self.__passenger_temp_setting = (
+            data["passenger_temp_setting"] if "passenger_temp_setting" in data else None
+        )
+        self.__remote_heater_control_enabled = (
+            data["remote_heater_control_enabled"]
+            if "remote_heater_control_enabled" in data
+            else None
+        )
+        self.__right_temp_direction = (
+            data["right_temp_direction"] if "right_temp_direction" in data else None
+        )
+        self.__seat_heater_left = (
+            data["seat_heater_left"] if "seat_heater_left" in data else None
+        )
+        self.__seat_heater_rear_center = (
+            data["seat_heater_rear_center"]
+            if "seat_heater_rear_center" in data
+            else None
+        )
+        self.__seat_heater_rear_left = (
+            data["seat_heater_rear_left"] if "seat_heater_rear_left" in data else None
+        )
+        self.__seat_heater_rear_left_back = (
+            data["seat_heater_rear_left_back"]
+            if "seat_heater_rear_left_back" in data
+            else None
+        )
+        self.__seat_heater_rear_right = (
+            data["seat_heater_rear_right"] if "seat_heater_rear_right" in data else None
+        )
+        self.__seat_heater_rear_right_back = (
+            data["seat_heater_rear_right_back"]
+            if "seat_heater_rear_right_back" in data
+            else None
+        )
+        self.__seat_heater_right = (
+            data["seat_heater_right"] if "seat_heater_right" in data else None
+        )
+        self.__side_mirror_heaters = (
+            data["side_mirror_heaters"] if "side_mirror_heaters" in data else None
+        )
+        self.__steering_wheel_heater = (
+            data["steering_wheel_heater"] if "steering_wheel_heater" in data else None
+        )
+        self.__timestamp = data["timestamp"] if "timestamp" in data else None
+        self.__wiper_blade_heater = (
+            data["wiper_blade_heater"] if "wiper_blade_heater" in data else None
+        )
 
     @property
     def battery_heater(self) -> bool:

--- a/teslajsonpy/library/model/climate_state.py
+++ b/teslajsonpy/library/model/climate_state.py
@@ -1,0 +1,196 @@
+#  SPDX-License-Identifier: Apache-2.0
+"""Tesla vehicle climate state model."""
+
+from typing import Text
+
+
+class ClimateStateModel:  # pylint: disable-msg=R0904
+    """Tesla vehicle climate state model.
+
+    The model is represented by the climate state API results.
+    See also: https://tesla-api.timdorr.com/vehicle/state/climatestate
+    """
+
+    def __init__(self):
+        """Initialize the climate state model."""
+
+        self.__battery_heater = None
+        self.__battery_heater_no_power = None
+        self.__climate_keeper_mode = None
+        self.__defrost_mode = None
+        self.__driver_temp_setting = None
+        self.__fan_status = None
+        self.__inside_temp = None
+        self.__is_auto_conditioning_on = None
+        self.__is_climate_on = None
+        self.__is_front_defroster_on = None
+        self.__is_preconditioning = None
+        self.__is_rear_defroster_on = None
+        self.__left_temp_direction = None
+        self.__max_avail_temp = None
+        self.__min_avail_temp = None
+        self.__outside_temp = None
+        self.__passenger_temp_setting = None
+        self.__remote_heater_control_enabled = None
+        self.__right_temp_direction = None
+        self.__seat_heater_left = None
+        self.__seat_heater_rear_center = None
+        self.__seat_heater_rear_left = None
+        self.__seat_heater_rear_left_back = None
+        self.__seat_heater_rear_right = None
+        self.__seat_heater_rear_right_back = None
+        self.__seat_heater_right = None
+        self.__side_mirror_heaters = None
+        self.__steering_wheel_heater = None
+        self.__timestamp = None
+        self.__wiper_blade_heater = None
+
+    @property
+    def battery_heater(self) -> bool:
+        """Return the battery_heater."""
+        return self.__battery_heater
+
+    @property
+    def battery_heater_no_power(self) -> bool:
+        """Return the battery_heater_no_power."""
+        return self.__battery_heater_no_power
+
+    @property
+    def climate_keeper_mode(self) -> Text:
+        """Return the climate_keeper_mode."""
+        return self.__climate_keeper_mode
+
+    @property
+    def defrost_mode(self) -> int:
+        """Return the defrost_mode."""
+        return self.__defrost_mode
+
+    @property
+    def driver_temp_setting(self) -> float:
+        """Return the driver_temp_setting."""
+        return self.__driver_temp_setting
+
+    @property
+    def fan_status(self) -> int:
+        """Return the fan_status."""
+        return self.__fan_status
+
+    @property
+    def inside_temp(self) -> float:
+        """Return the inside_temp."""
+        return self.__inside_temp
+
+    @property
+    def is_auto_conditioning_on(self) -> bool:
+        """Return the is_auto_conditioning_on."""
+        return self.__is_auto_conditioning_on
+
+    @property
+    def is_climate_on(self) -> bool:
+        """Return the is_climate_on."""
+        return self.__is_climate_on
+
+    @property
+    def is_front_defroster_on(self) -> bool:
+        """Return the is_front_defroster_on."""
+        return self.__is_front_defroster_on
+
+    @property
+    def is_preconditioning(self) -> bool:
+        """Return the is_preconditioning."""
+        return self.__is_preconditioning
+
+    @property
+    def is_rear_defroster_on(self) -> bool:
+        """Return the is_rear_defroster_on."""
+        return self.__is_rear_defroster_on
+
+    @property
+    def left_temp_direction(self):
+        """Return the left_temp_direction."""
+        return self.__left_temp_direction
+
+    @property
+    def max_avail_temp(self) -> float:
+        """Return the max_avail_temp."""
+        return self.__max_avail_temp
+
+    @property
+    def min_avail_temp(self) -> float:
+        """Return the min_avail_temp."""
+        return self.__min_avail_temp
+
+    @property
+    def outside_temp(self) -> float:
+        """Return the outside_temp."""
+        return self.__outside_temp
+
+    @property
+    def passenger_temp_setting(self) -> float:
+        """Return the passenger_temp_setting."""
+        return self.__passenger_temp_setting
+
+    @property
+    def remote_heater_control_enabled(self) -> bool:
+        """Return the remote_heater_control_enabled."""
+        return self.__remote_heater_control_enabled
+
+    @property
+    def right_temp_direction(self):
+        """Return the right_temp_direction."""
+        return self.__right_temp_direction
+
+    @property
+    def seat_heater_left(self) -> int:
+        """Return the seat_heater_left."""
+        return self.__seat_heater_left
+
+    @property
+    def seat_heater_rear_center(self) -> int:
+        """Return the seat_heater_rear_center."""
+        return self.__seat_heater_rear_center
+
+    @property
+    def seat_heater_rear_left(self) -> int:
+        """Return the seat_heater_rear_left."""
+        return self.__seat_heater_rear_left
+
+    @property
+    def seat_heater_rear_left_back(self) -> int:
+        """Return the seat_heater_rear_left_back."""
+        return self.__seat_heater_rear_left_back
+
+    @property
+    def seat_heater_rear_right(self) -> int:
+        """Return the seat_heater_rear_right."""
+        return self.__seat_heater_rear_right
+
+    @property
+    def seat_heater_rear_right_back(self) -> int:
+        """Return the seat_heater_rear_right_back."""
+        return self.__seat_heater_rear_right_back
+
+    @property
+    def seat_heater_right(self) -> int:
+        """Return the seat_heater_right."""
+        return self.__seat_heater_right
+
+    @property
+    def side_mirror_heaters(self) -> bool:
+        """Return the side_mirror_heaters."""
+        return self.__side_mirror_heaters
+
+    @property
+    def steering_wheel_heater(self) -> bool:
+        """Return the steering_wheel_heater."""
+        return self.__steering_wheel_heater
+
+    @property
+    def timestamp(self) -> int:
+        """Return the timestamp."""
+        return self.__timestamp
+
+    @property
+    def wiper_blade_heater(self) -> bool:
+        """Return the wiper_blade_heater."""
+        return self.__wiper_blade_heater

--- a/teslajsonpy/library/model/drive_state.py
+++ b/teslajsonpy/library/model/drive_state.py
@@ -1,0 +1,88 @@
+#  SPDX-License-Identifier: Apache-2.0
+"""Tesla vehicle drive state model."""
+
+from typing import Text
+
+
+class DriveStateModel:
+    """Tesla vehicle drive state model.
+
+    The model is represented by the drive state API results.
+    See also: https://tesla-api.timdorr.com/vehicle/state/drivestate
+    """
+
+    def __init__(self):
+        """Initialize the drive state model."""
+
+        self.__gps_as_of = None
+        self.__heading = None
+        self.__latitude = None
+        self.__longitude = None
+        self.__native_latitude = None
+        self.__native_location_supported = None
+        self.__native_longitude = None
+        self.__native_type = None
+        self.__power = None
+        self.__shift_state = None
+        self.__speed = None
+        self.__timestamp = None
+
+    @property
+    def gps_as_of(self) -> int:
+        """Return the gps_as_of."""
+        return self.__gps_as_of
+
+    @property
+    def heading(self) -> int:
+        """Return the heading."""
+        return self.__heading
+
+    @property
+    def latitude(self) -> float:
+        """Return the latitude."""
+        return self.__latitude
+
+    @property
+    def longitude(self) -> float:
+        """Return the longitude."""
+        return self.__longitude
+
+    @property
+    def native_latitude(self) -> float:
+        """Return the native_latitude."""
+        return self.__native_latitude
+
+    @property
+    def native_location_supported(self) -> int:
+        """Return the native_location_supported."""
+        return self.__native_location_supported
+
+    @property
+    def native_longitude(self) -> float:
+        """Return the native_longitude."""
+        return self.__native_longitude
+
+    @property
+    def native_type(self) -> Text:
+        """Return the native_type."""
+        return self.__native_type
+
+    @property
+    def power(self) -> int:
+        """Return the power."""
+        return self.__power
+
+    @property
+    def shift_state(self):
+        """Return the shift_state."""
+        return self.__shift_state
+
+    @property
+    def speed(self) -> float:
+        """Return the speed."""
+        return self.__speed
+
+    @property
+    def timestamp(self) -> int:
+        """Return the timestamp."""
+        return self.__timestamp

--- a/teslajsonpy/library/model/drive_state.py
+++ b/teslajsonpy/library/model/drive_state.py
@@ -1,7 +1,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 """Tesla vehicle drive state model."""
 
-from typing import Text
+from typing import Dict, Text
 
 
 class DriveStateModel:
@@ -26,6 +26,30 @@ class DriveStateModel:
         self.__shift_state = None
         self.__speed = None
         self.__timestamp = None
+
+    def load(self, data: Dict) -> None:
+        """Load data from a JSON result."""
+
+        self.__gps_as_of = data["gps_as_of"] if "gps_as_of" in data else None
+        self.__heading = data["heading"] if "heading" in data else None
+        self.__latitude = data["latitude"] if "latitude" in data else None
+        self.__longitude = data["longitude"] if "longitude" in data else None
+        self.__native_latitude = (
+            data["native_latitude"] if "native_latitude" in data else None
+        )
+        self.__native_location_supported = (
+            data["native_location_supported"]
+            if "native_location_supported" in data
+            else None
+        )
+        self.__native_longitude = (
+            data["native_longitude"] if "native_longitude" in data else None
+        )
+        self.__native_type = data["native_type"] if "native_type" in data else None
+        self.__power = data["power"] if "power" in data else None
+        self.__shift_state = data["shift_state"] if "shift_state" in data else None
+        self.__speed = data["speed"] if "speed" in data else None
+        self.__timestamp = data["timestamp"] if "timestamp" in data else None
 
     @property
     def gps_as_of(self) -> int:

--- a/teslajsonpy/library/model/gui_settings.py
+++ b/teslajsonpy/library/model/gui_settings.py
@@ -1,0 +1,58 @@
+#  SPDX-License-Identifier: Apache-2.0
+"""Tesla vehicle GUI settings model."""
+
+from typing import Text
+
+
+class GuiSettingsModel:
+    """Tesla vehicle GUI settings model.
+
+    The model is represented by the GUI settings API results.
+    See also: https://tesla-api.timdorr.com/vehicle/state/guisettings
+    """
+
+    def __init__(self):
+        """Initialize the GUI settings model."""
+
+        self.__gui_24_hour_time = None
+        self.__gui_charge_rate_units = None
+        self.__gui_distance_units = None
+        self.__gui_range_display = None
+        self.__gui_temperature_units = None
+        self.__show_range_units = None
+        self.__timestamp = None
+
+    @property
+    def gui_24_hour_time(self) -> bool:
+        """Return the gui_24_hour_time."""
+        return self.__gui_24_hour_time
+
+    @property
+    def gui_charge_rate_units(self) -> Text:
+        """Return the gui_charge_rate_units."""
+        return self.__gui_charge_rate_units
+
+    @property
+    def gui_distance_units(self) -> Text:
+        """Return the gui_distance_units."""
+        return self.__gui_distance_units
+
+    @property
+    def gui_range_display(self) -> Text:
+        """Return the gui_range_display."""
+        return self.__gui_range_display
+
+    @property
+    def gui_temperature_units(self) -> Text:
+        """Return the gui_temperature_units."""
+        return self.__gui_temperature_units
+
+    @property
+    def show_range_units(self) -> bool:
+        """Return the show_range_units."""
+        return self.__show_range_units
+
+    @property
+    def timestamp(self) -> int:
+        """Return the timestamp."""
+        return self.__timestamp

--- a/teslajsonpy/library/model/gui_settings.py
+++ b/teslajsonpy/library/model/gui_settings.py
@@ -1,7 +1,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 """Tesla vehicle GUI settings model."""
 
-from typing import Text
+from typing import Dict, Text
 
 
 class GuiSettingsModel:
@@ -21,6 +21,29 @@ class GuiSettingsModel:
         self.__gui_temperature_units = None
         self.__show_range_units = None
         self.__timestamp = None
+
+    def load(self, data: Dict) -> None:
+        """Load data from a JSON result."""
+
+        self.__gui_24_hour_time = (
+            data["gui_24_hour_time"] if "gui_24_hour_time" in data else None
+        )
+        self.__gui_charge_rate_units = (
+            data["gui_charge_rate_units"] if "gui_charge_rate_units" in data else None
+        )
+        self.__gui_distance_units = (
+            data["gui_distance_units"] if "gui_distance_units" in data else None
+        )
+        self.__gui_range_display = (
+            data["gui_range_display"] if "gui_range_display" in data else None
+        )
+        self.__gui_temperature_units = (
+            data["gui_temperature_units"] if "gui_temperature_units" in data else None
+        )
+        self.__show_range_units = (
+            data["show_range_units"] if "show_range_units" in data else None
+        )
+        self.__timestamp = data["timestamp"] if "timestamp" in data else None
 
     @property
     def gui_24_hour_time(self) -> bool:

--- a/teslajsonpy/library/model/token.py
+++ b/teslajsonpy/library/model/token.py
@@ -1,0 +1,52 @@
+#  SPDX-License-Identifier: Apache-2.0
+"""Tesla vehicle charge state model."""
+
+from typing import Text
+
+
+class TokenModel:
+    """Tesla OAuth authentication token model.
+
+    The model is represented by the token API results.
+    See also: https://tesla-api.timdorr.com/api-basics/authentication
+    """
+
+    def __init__(
+        self,
+        access_token: Text,
+        refresh_token: Text,
+        created_at: int,
+        expires_in: int = 3888000,
+        token_type: Text = "bearer",
+    ):
+        """Initialize the authentication token."""
+        self._access_token: Text = access_token
+        self._refresh_token: Text = refresh_token
+        self._created_at: int = created_at
+        self._token_type: Text = token_type
+        self._expires_in: int = expires_in
+
+    @property
+    def access_token(self) -> Text:
+        """Return the access token."""
+        return self._access_token
+
+    @property
+    def token_type(self) -> Text:
+        """Return the access token type."""
+        return self._token_type
+
+    @property
+    def expires_in(self) -> int:
+        """Return the access token expiration duration."""
+        return self._expires_in
+
+    @property
+    def refresh_token(self) -> Text:
+        """Return the refresh token."""
+        return self._refresh_token
+
+    @property
+    def created_at(self) -> int:
+        """Return the access token creation timestamp."""
+        return self._created_at

--- a/teslajsonpy/library/model/vehicle.py
+++ b/teslajsonpy/library/model/vehicle.py
@@ -18,10 +18,10 @@ class VehicleModel:  # pylint: disable-msg=R0904
     See also: https://tesla-api.timdorr.com/vehicle/state/data
     """
 
-    def __init__(self):
+    def __init__(self, identifier: Text = None):
         """Initialize the model."""
 
-        self.__id = None
+        self.__id = identifier
         self.__user_id = None
         self.__vehicle_id = None
         self.__vin = None
@@ -41,6 +41,74 @@ class VehicleModel:  # pylint: disable-msg=R0904
         self.__gui_settings = None
         self.__vehicle_state = None
         self.__vehicle_config = None
+
+    def load(self, data: Dict) -> None:
+        """Load vehicle data from a JSON result."""
+
+        self.__id = data["id"] if "id" in data else None
+        self.__user_id = data["user_id"] if "user_id" in data else None
+        self.__vehicle_id = data["vehicle_id"] if "vehicle_id" in data else None
+        self.__vin = data["vin"] if "vin" in data else None
+        self.__display_name = data["display_name"] if "display_name" in data else None
+        self.__option_codes = data["option_codes"] if "option_codes" in data else None
+        self.__color = data["color"] if "color" in data else None
+        self.__tokens = data["tokens"] if "tokens" in data else None
+        self.__state = data["state"] if "state" in data else None
+        self.__in_service = data["in_service"] if "in_service" in data else False
+        self.__calendar_enabled = (
+            data["calendar_enabled"] if "calendar_enabled" in data else False
+        )
+        self.__api_version = data["api_version"] if "api_version" in data else None
+        self.__backseat_token = (
+            data["backseat_token"] if "backseat_token" in data else None
+        )
+        self.__backseat_token_updated_at = (
+            data["backseat_token_updated_at"]
+            if "backseat_token_updated_at" in data
+            else None
+        )
+
+        if "drive_state" in data:
+            drive_state = DriveStateModel()
+            drive_state.load(data["drive_state"])
+            self.__drive_state = drive_state
+        else:
+            self.__drive_state = None
+
+        if "climate_state" in data:
+            climate_state = ClimateStateModel()
+            climate_state.load(data["climate_state"])
+            self.__climate_state = climate_state
+        else:
+            self.__climate_state = None
+
+        if "charge_state" in data:
+            charge_state = ChargeStateModel()
+            charge_state.load(data["charge_state"])
+            self.__charge_state = charge_state
+        else:
+            self.__charge_state = None
+
+        if "gui_settings" in data:
+            gui_settings = GuiSettingsModel()
+            gui_settings.load(data["gui_settings"])
+            self.__gui_settings = gui_settings
+        else:
+            self.__gui_settings = None
+
+        if "vehicle_state" in data:
+            vehicle_state = VehicleStateModel()
+            vehicle_state.load(data["vehicle_state"])
+            self.__vehicle_state = vehicle_state
+        else:
+            self.__vehicle_state = None
+
+        if "vehicle_config" in data:
+            vehicle_config = VehicleConfigModel()
+            vehicle_config.load(data["vehicle_config"])
+            self.__vehicle_config = vehicle_config
+        else:
+            self.__vehicle_config = None
 
     @property
     def id(self) -> int:

--- a/teslajsonpy/library/model/vehicle.py
+++ b/teslajsonpy/library/model/vehicle.py
@@ -1,0 +1,159 @@
+#  SPDX-License-Identifier: Apache-2.0
+"""Tesla vehicle model."""
+
+from typing import Dict, Text
+
+from teslajsonpy.library.model.charge_state import ChargeStateModel
+from teslajsonpy.library.model.climate_state import ClimateStateModel
+from teslajsonpy.library.model.drive_state import DriveStateModel
+from teslajsonpy.library.model.gui_settings import GuiSettingsModel
+from teslajsonpy.library.model.vehicle_config import VehicleConfigModel
+from teslajsonpy.library.model.vehicle_state import VehicleStateModel
+
+
+class VehicleModel:  # pylint: disable-msg=R0904
+    """Tesla vehicle model.
+
+    The model is represented by the API vehicle state results.
+    See also: https://tesla-api.timdorr.com/vehicle/state/data
+    """
+
+    def __init__(self):
+        """Initialize the model."""
+
+        self.__id = None
+        self.__user_id = None
+        self.__vehicle_id = None
+        self.__vin = None
+        self.__display_name = None
+        self.__option_codes = None
+        self.__color = None
+        self.__tokens = None
+        self.__state = None
+        self.__in_service = False
+        self.__calendar_enabled = False
+        self.__api_version = None
+        self.__backseat_token = None
+        self.__backseat_token_updated_at = None
+        self.__drive_state = None
+        self.__climate_state = None
+        self.__charge_state = None
+        self.__gui_settings = None
+        self.__vehicle_state = None
+        self.__vehicle_config = None
+
+    @property
+    def id(self) -> int:
+        """Return the vehicle ID.
+
+        The id field is an identifier for the car on the owner-api endpoint.
+        The vehicle_id field is for identifying the car across different endpoints.
+        """
+        return self.__id
+
+    @property
+    def user_id(self) -> int:
+        """Return the vehicle user ID."""
+        return self.__user_id
+
+    @property
+    def vehicle_id(self) -> int:
+        """Return the vehicle ID.
+
+        The vehicle_id field is for identifying the car across different endpoints.
+        The id field is an identifier for the car on the owner-api endpoint.
+        """
+        return self.__vehicle_id
+
+    @property
+    def vin(self) -> Text:
+        """Return the vehicle VIN."""
+        return self.__vin
+
+    @property
+    def display_name(self) -> Text:
+        """Return the vehicle name."""
+        return self.__display_name
+
+    @property
+    def option_codes(self) -> Dict:
+        """Return the vehicle option codes."""
+        return self.__option_codes
+
+    @property
+    def color(self) -> Text:
+        """Return the vehicle color."""
+        return self.__color
+
+    @property
+    def tokens(self) -> Dict:
+        """Return the vehicle tokens."""
+        return self.__tokens
+
+    @property
+    def state(self) -> Text:
+        """Return the vehicle state."""
+        return self.__state
+
+    @property
+    def in_service(self) -> bool:
+        """."""
+        return self.__in_service
+
+    @property
+    def id_s(self) -> Text:
+        """Return the vehicle ID as a string.
+
+        The id field is an identifier for the car on the owner-api endpoint.
+        """
+        return f"{self.id}"
+
+    @property
+    def calendar_enabled(self) -> bool:
+        """Return True of calendar is enabled."""
+        return self.__calendar_enabled
+
+    @property
+    def api_version(self) -> Text:
+        """Return the vehicle API version."""
+        return self.__api_version
+
+    @property
+    def backseat_token(self):
+        """Return the backseat token."""
+        return self.__backseat_token
+
+    @property
+    def backseat_token_updated_at(self):
+        """Return the backseat token last update time."""
+        return self.__backseat_token_updated_at
+
+    @property
+    def drive_state(self) -> DriveStateModel:
+        """Return the vehicle drive state."""
+        return self.__drive_state
+
+    @property
+    def climate_state(self) -> ClimateStateModel:
+        """Return the vehicle climate state."""
+        return self.__climate_state
+
+    @property
+    def charge_state(self) -> ChargeStateModel:
+        """Return the vehicle charge state."""
+        return self.__charge_state
+
+    @property
+    def gui_settings(self) -> GuiSettingsModel:
+        """Return the vehicle GUI settings."""
+        return self.__gui_settings
+
+    @property
+    def vehicle_state(self) -> VehicleStateModel:
+        """Return the vehicle vehicle state."""
+        return self.__vehicle_state
+
+    @property
+    def vehicle_config(self) -> VehicleConfigModel:
+        """Return the vehicle vehicle config."""
+        return self.__vehicle_config

--- a/teslajsonpy/library/model/vehicle_config.py
+++ b/teslajsonpy/library/model/vehicle_config.py
@@ -1,0 +1,160 @@
+#  SPDX-License-Identifier: Apache-2.0
+"""Tesla vehicle config model."""
+
+from typing import Text
+
+
+class VehicleConfigModel:  # pylint: disable-msg=R0904
+    """Tesla vehicle config model.
+
+    The model is represented by the vehicle config API results.
+    See also: https://tesla-api.timdorr.com/vehicle/state/vehicleconfig
+    """
+
+    def __init__(self):
+        """Initialize the vehicle config model."""
+
+        self.__can_accept_navigation_requests = None
+        self.__can_actuate_trunks = None
+        self.__car_special_type = None
+        self.__car_type = None
+        self.__charge_port_type = None
+        self.__eu_vehicle = None
+        self.__exterior_color = None
+        self.__has_air_suspension = None
+        self.__has_ludicrous_mode = None
+        self.__key_version = None
+        self.__motorized_charge_port = None
+        self.__perf_config = None
+        self.__plg = None
+        self.__rear_seat_heaters = None
+        self.__rear_seat_type = None
+        self.__rhd = None
+        self.__roof_color = None
+        self.__seat_type = None
+        self.__spoiler_type = None
+        self.__sun_roof_installed = None
+        self.__third_row_seats = None
+        self.__timestamp = None
+        self.__trim_badging = None
+        self.__wheel_type = None
+
+    @property
+    def can_accept_navigation_requests(self) -> bool:
+        """Return the can_accept_navigation_requests."""
+        return self.__can_accept_navigation_requests
+
+    @property
+    def can_actuate_trunks(self) -> bool:
+        """Return the can_actuate_trunks."""
+        return self.__can_actuate_trunks
+
+    @property
+    def car_special_type(self) -> Text:
+        """Return the car_special_type."""
+        return self.__car_special_type
+
+    @property
+    def car_type(self) -> Text:
+        """Return the car_type."""
+        return self.__car_type
+
+    @property
+    def charge_port_type(self) -> Text:
+        """Return the charge_port_type."""
+        return self.__charge_port_type
+
+    @property
+    def eu_vehicle(self) -> bool:
+        """Return the eu_vehicle."""
+        return self.__eu_vehicle
+
+    @property
+    def exterior_color(self) -> Text:
+        """Return the exterior_color."""
+        return self.__exterior_color
+
+    @property
+    def has_air_suspension(self) -> bool:
+        """Return the has_air_suspension."""
+        return self.__has_air_suspension
+
+    @property
+    def has_ludicrous_mode(self) -> bool:
+        """Return the has_ludicrous_mode."""
+        return self.__has_ludicrous_mode
+
+    @property
+    def key_version(self) -> int:
+        """Return the key_version."""
+        return self.__key_version
+
+    @property
+    def motorized_charge_port(self) -> bool:
+        """Return the motorized_charge_port."""
+        return self.__motorized_charge_port
+
+    @property
+    def perf_config(self) -> Text:
+        """Return the perf_config."""
+        return self.__perf_config
+
+    @property
+    def plg(self) -> bool:
+        """Return the plg."""
+        return self.__plg
+
+    @property
+    def rear_seat_heaters(self) -> int:
+        """Return the rear_seat_heaters."""
+        return self.__rear_seat_heaters
+
+    @property
+    def rear_seat_type(self) -> int:
+        """Return the rear_seat_type."""
+        return self.__rear_seat_type
+
+    @property
+    def rhd(self) -> bool:
+        """Return the rhd."""
+        return self.__rhd
+
+    @property
+    def roof_color(self) -> Text:
+        """Return the roof_color."""
+        return self.__roof_color
+
+    @property
+    def seat_type(self) -> int:
+        """Return the seat_type."""
+        return self.__seat_type
+
+    @property
+    def spoiler_type(self) -> Text:
+        """Return the spoiler_type."""
+        return self.__spoiler_type
+
+    @property
+    def sun_roof_installed(self) -> int:
+        """Return the sun_roof_installed."""
+        return self.__sun_roof_installed
+
+    @property
+    def third_row_seats(self) -> Text:
+        """Return the third_row_seats."""
+        return self.__third_row_seats
+
+    @property
+    def timestamp(self) -> int:
+        """Return the timestamp."""
+        return self.__timestamp
+
+    @property
+    def trim_badging(self) -> Text:
+        """Return the trim_badging."""
+        return self.__trim_badging
+
+    @property
+    def wheel_type(self) -> Text:
+        """Return the wheel_type."""
+        return self.__wheel_type

--- a/teslajsonpy/library/model/vehicle_config.py
+++ b/teslajsonpy/library/model/vehicle_config.py
@@ -1,7 +1,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 """Tesla vehicle config model."""
 
-from typing import Text
+from typing import Dict, Text
 
 
 class VehicleConfigModel:  # pylint: disable-msg=R0904
@@ -37,7 +37,65 @@ class VehicleConfigModel:  # pylint: disable-msg=R0904
         self.__third_row_seats = None
         self.__timestamp = None
         self.__trim_badging = None
+        self.__use_range_badging = None
         self.__wheel_type = None
+
+    def load(self, data: Dict) -> None:
+        """Load data from a JSON result."""
+
+        self.__can_accept_navigation_requests = (
+            data["can_accept_navigation_requests"]
+            if "can_accept_navigation_requests" in data
+            else None
+        )
+        self.__can_actuate_trunks = (
+            data["can_actuate_trunks"] if "can_actuate_trunks" in data else None
+        )
+        self.__car_special_type = (
+            data["car_special_type"] if "car_special_type" in data else None
+        )
+        self.__car_type = data["car_type"] if "car_type" in data else None
+        self.__charge_port_type = (
+            data["charge_port_type"] if "charge_port_type" in data else None
+        )
+        self.__eu_vehicle = data["eu_vehicle"] if "eu_vehicle" in data else None
+        self.__exterior_color = (
+            data["exterior_color"] if "exterior_color" in data else None
+        )
+        self.__has_air_suspension = (
+            data["has_air_suspension"] if "has_air_suspension" in data else None
+        )
+        self.__has_ludicrous_mode = (
+            data["has_ludicrous_mode"] if "has_ludicrous_mode" in data else None
+        )
+        self.__key_version = data["key_version"] if "key_version" in data else None
+        self.__motorized_charge_port = (
+            data["motorized_charge_port"] if "motorized_charge_port" in data else None
+        )
+        self.__perf_config = data["perf_config"] if "perf_config" in data else None
+        self.__plg = data["plg"] if "plg" in data else None
+        self.__rear_seat_heaters = (
+            data["rear_seat_heaters"] if "rear_seat_heaters" in data else None
+        )
+        self.__rear_seat_type = (
+            data["rear_seat_type"] if "rear_seat_type" in data else None
+        )
+        self.__rhd = data["rhd"] if "rhd" in data else None
+        self.__roof_color = data["roof_color"] if "roof_color" in data else None
+        self.__seat_type = data["seat_type"] if "seat_type" in data else None
+        self.__spoiler_type = data["spoiler_type"] if "spoiler_type" in data else None
+        self.__sun_roof_installed = (
+            data["sun_roof_installed"] if "sun_roof_installed" in data else None
+        )
+        self.__third_row_seats = (
+            data["third_row_seats"] if "third_row_seats" in data else None
+        )
+        self.__timestamp = data["timestamp"] if "timestamp" in data else None
+        self.__trim_badging = data["trim_badging"] if "trim_badging" in data else None
+        self.__use_range_badging = (
+            data["use_range_badging"] if "use_range_badging" in data else None
+        )
+        self.__wheel_type = data["wheel_type"] if "wheel_type" in data else None
 
     @property
     def can_accept_navigation_requests(self) -> bool:
@@ -153,6 +211,11 @@ class VehicleConfigModel:  # pylint: disable-msg=R0904
     def trim_badging(self) -> Text:
         """Return the trim_badging."""
         return self.__trim_badging
+
+    @property
+    def use_range_badging(self) -> bool:
+        """Return the use_range_badging."""
+        return self.__use_range_badging
 
     @property
     def wheel_type(self) -> Text:

--- a/teslajsonpy/library/model/vehicle_state.py
+++ b/teslajsonpy/library/model/vehicle_state.py
@@ -1,0 +1,370 @@
+#  SPDX-License-Identifier: Apache-2.0
+"""Tesla vehicle state model."""
+
+from typing import Text
+
+
+class MediaStateModel:  # pylint: disable-msg=R0903
+    """Tesla vehicle media state model.
+
+    The model is represented by the vehicle state API results.
+    See also: https://tesla-api.timdorr.com/vehicle/state/vehiclestate
+    """
+
+    def __init__(self):
+        """Initialize the media state model."""
+
+        self.__remote_control_enabled = None
+
+    @property
+    def remote_control_enabled(self) -> bool:
+        """Return the remote_control_enabled."""
+        return self.__remote_control_enabled
+
+
+class SoftwareUpdateModel:
+    """Tesla vehicle software update model.
+
+    The model is represented by the vehicle state API results.
+    See also: https://tesla-api.timdorr.com/vehicle/state/vehiclestate
+    """
+
+    def __init__(self):
+        """Initialize the software update model."""
+
+        self.__download_perc = None
+        self.__expected_duration_sec = None
+        self.__install_perc = None
+        self.__scheduled_time_ms = None
+        self.__status = None
+        self.__version = None
+
+    @property
+    def download_perc(self) -> int:
+        """Return the download_perc."""
+        return self.__download_perc
+
+    @property
+    def expected_duration_sec(self) -> int:
+        """Return the expected_duration_sec."""
+        return self.__expected_duration_sec
+
+    @property
+    def install_perc(self) -> int:
+        """Return the install_perc."""
+        return self.__install_perc
+
+    @property
+    def scheduled_time_ms(self) -> int:
+        """Return the scheduled_time_ms."""
+        return self.__scheduled_time_ms
+
+    @property
+    def status(self) -> Text:
+        """Return the status."""
+        return self.__status
+
+    @property
+    def version(self) -> Text:
+        """Return the version."""
+        return self.__version
+
+
+class SpeedLimitModeModel:
+    """Tesla vehicle speed limit mode model.
+
+    The model is represented by the vehicle state API results.
+    See also: https://tesla-api.timdorr.com/vehicle/state/vehiclestate
+    """
+
+    def __init__(self):
+        """Initialize the speed limit mode model."""
+
+        self.__active = None
+        self.__current_limit_mph = None
+        self.__max_limit_mph = None
+        self.__min_limit_mph = None
+        self.__pin_code_set = None
+
+    @property
+    def active(self) -> bool:
+        """Return the active."""
+        return self.__active
+
+    @property
+    def current_limit_mph(self) -> bool:
+        """Return the current_limit_mph."""
+        return self.__current_limit_mph
+
+    @property
+    def max_limit_mph(self) -> bool:
+        """Return the max_limit_mph."""
+        return self.__max_limit_mph
+
+    @property
+    def min_limit_mph(self) -> bool:
+        """Return the min_limit_mph."""
+        return self.__min_limit_mph
+
+    @property
+    def pin_code_set(self) -> bool:
+        """Return the pin_code_set."""
+        return self.__pin_code_set
+
+
+class VehicleStateModel:  # pylint: disable-msg=R0904
+    """Tesla vehicle state model.
+
+    The model is represented by the vehicle state API results.
+    See also: https://tesla-api.timdorr.com/vehicle/state/vehiclestate
+    """
+
+    def __init__(self):
+        """Initialize the vehicle state model."""
+
+        self.__api_version = None
+        self.__autopark_state_v3 = None
+        self.__autopark_style = None
+        self.__calendar_supported = None
+        self.__car_version = None
+        self.__center_display_state = None
+        self.__df = None
+        self.__dr = None
+        self.__fd_window = None
+        self.__fp_window = None
+        self.__ft = None
+        self.__homelink_device_count = None
+        self.__homelink_nearby = None
+        self.__is_user_present = None
+        self.__last_autopark_error = None
+        self.__locked = None
+        self.__media_state = None
+        self.__notifications_supported = None
+        self.__odometer = None
+        self.__parsed_calendar_supported = None
+        self.__pf = None
+        self.__pr = None
+        self.__rd_window = None
+        self.__remote_start = None
+        self.__remote_start_enabled = None
+        self.__remote_start_supported = None
+        self.__rp_window = None
+        self.__rt = None
+        self.__sentry_mode = None
+        self.__sentry_mode_available = None
+        self.__smart_summon_available = None
+        self.__software_update = None
+        self.__speed_limit_mode = None
+        self.__summon_standby_mode_enabled = None
+        self.__sun_roof_percent_open = None
+        self.__sun_roof_state = None
+        self.__timestamp = None
+        self.__valet_mode = None
+        self.__valet_pin_needed = None
+        self.__vehicle_name = None
+
+    @property
+    def api_version(self) -> int:
+        """Return the api_version."""
+        return self.__api_version
+
+    @property
+    def autopark_state_v3(self) -> Text:
+        """Return the autopark_state_v3."""
+        return self.__autopark_state_v3
+
+    @property
+    def autopark_style(self) -> Text:
+        """Return the autopark_style."""
+        return self.__autopark_style
+
+    @property
+    def calendar_supported(self) -> bool:
+        """Return the calendar_supported."""
+        return self.__calendar_supported
+
+    @property
+    def car_version(self) -> Text:
+        """Return the car_version."""
+        return self.__car_version
+
+    @property
+    def center_display_state(self) -> int:
+        """Return the center_display_state."""
+        return self.__center_display_state
+
+    @property
+    # pylint: disable=C0103
+    def df(self) -> int:
+        """Return the df."""
+        return self.__df
+
+    @property
+    # pylint: disable=C0103
+    def dr(self) -> int:
+        """Return the dr."""
+        return self.__dr
+
+    @property
+    def fd_window(self) -> int:
+        """Return the fd_window."""
+        return self.__fd_window
+
+    @property
+    def fp_window(self) -> int:
+        """Return the fp_window."""
+        return self.__fp_window
+
+    @property
+    # pylint: disable=C0103
+    def ft(self) -> int:
+        """Return the ft."""
+        return self.__ft
+
+    @property
+    def homelink_device_count(self) -> int:
+        """Return the homelink_device_count."""
+        return self.__homelink_device_count
+
+    @property
+    def homelink_nearby(self) -> bool:
+        """Return the homelink_nearby."""
+        return self.__homelink_nearby
+
+    @property
+    def is_user_present(self) -> bool:
+        """Return the is_user_present."""
+        return self.__is_user_present
+
+    @property
+    def last_autopark_error(self) -> Text:
+        """Return the last_autopark_error."""
+        return self.__last_autopark_error
+
+    @property
+    def locked(self) -> bool:
+        """Return the locked."""
+        return self.__locked
+
+    @property
+    def media_state(self) -> MediaStateModel:
+        """Return the media_state."""
+        return self.__media_state
+
+    @property
+    def notifications_supported(self) -> bool:
+        """Return the notifications_supported."""
+        return self.__notifications_supported
+
+    @property
+    def odometer(self) -> float:
+        """Return the odometer."""
+        return self.__odometer
+
+    @property
+    def parsed_calendar_supported(self) -> bool:
+        """Return the parsed_calendar_supported."""
+        return self.__parsed_calendar_supported
+
+    @property
+    # pylint: disable=C0103
+    def pf(self) -> int:
+        """Return the pf."""
+        return self.__pf
+
+    @property
+    # pylint: disable=C0103
+    def pr(self) -> int:
+        """Return the pr."""
+        return self.__pr
+
+    @property
+    def rd_window(self) -> int:
+        """Return the rd_window."""
+        return self.__rd_window
+
+    @property
+    def remote_start(self) -> bool:
+        """Return the remote_start."""
+        return self.__remote_start
+
+    @property
+    def remote_start_enabled(self) -> bool:
+        """Return the remote_start_enabled."""
+        return self.__remote_start_enabled
+
+    @property
+    def remote_start_supported(self) -> bool:
+        """Return the remote_start_supported."""
+        return self.__remote_start_supported
+
+    @property
+    def rp_window(self) -> int:
+        """Return the rp_window."""
+        return self.__rp_window
+
+    @property
+    # pylint: disable=C0103
+    def rt(self) -> int:
+        """Return the rt."""
+        return self.__rt
+
+    @property
+    def sentry_mode(self) -> bool:
+        """Return the sentry_mode."""
+        return self.__sentry_mode
+
+    @property
+    def sentry_mode_available(self) -> bool:
+        """Return the sentry_mode_available."""
+        return self.__sentry_mode_available
+
+    @property
+    def smart_summon_available(self) -> bool:
+        """Return the smart_summon_available."""
+        return self.__smart_summon_available
+
+    @property
+    def software_update(self) -> SoftwareUpdateModel:
+        """Return the software_update."""
+        return self.__software_update
+
+    @property
+    def speed_limit_mode(self) -> SpeedLimitModeModel:
+        """Return the speed_limit_mode."""
+        return self.__speed_limit_mode
+
+    @property
+    def summon_standby_mode_enabled(self) -> bool:
+        """Return the summon_standby_mode_enabled."""
+        return self.__summon_standby_mode_enabled
+
+    @property
+    def sun_roof_percent_open(self) -> bool:
+        """Return the sun_roof_percent_open."""
+        return self.__sun_roof_percent_open
+
+    @property
+    def sun_roof_state(self) -> Text:
+        """Return the sun_roof_state."""
+        return self.__sun_roof_state
+
+    @property
+    def timestamp(self) -> int:
+        """Return the timestamp."""
+        return self.__timestamp
+
+    @property
+    def valet_mode(self) -> bool:
+        """Return the valet_mode."""
+        return self.__valet_mode
+
+    @property
+    def valet_pin_needed(self) -> bool:
+        """Return the valet_pin_needed."""
+        return self.__valet_pin_needed
+
+    @property
+    def vehicle_name(self) -> Text:
+        """Return the vehicle_name."""
+        return self.__vehicle_name

--- a/teslajsonpy/library/model/vehicle_state.py
+++ b/teslajsonpy/library/model/vehicle_state.py
@@ -1,7 +1,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 """Tesla vehicle state model."""
 
-from typing import Text
+from typing import Dict, Text
 
 
 class MediaStateModel:  # pylint: disable-msg=R0903
@@ -15,6 +15,13 @@ class MediaStateModel:  # pylint: disable-msg=R0903
         """Initialize the media state model."""
 
         self.__remote_control_enabled = None
+
+    def load(self, data: Dict) -> None:
+        """Load data from a JSON result."""
+
+        self.__remote_control_enabled = (
+            data["remote_control_enabled"] if "remote_control_enabled" in data else None
+        )
 
     @property
     def remote_control_enabled(self) -> bool:
@@ -38,6 +45,22 @@ class SoftwareUpdateModel:
         self.__scheduled_time_ms = None
         self.__status = None
         self.__version = None
+
+    def load(self, data: Dict) -> None:
+        """Load data from a JSON result."""
+
+        self.__download_perc = (
+            data["download_perc"] if "download_perc" in data else None
+        )
+        self.__expected_duration_sec = (
+            data["expected_duration_sec"] if "expected_duration_sec" in data else None
+        )
+        self.__install_perc = data["install_perc"] if "install_perc" in data else None
+        self.__scheduled_time_ms = (
+            data["scheduled_time_ms"] if "scheduled_time_ms" in data else None
+        )
+        self.__status = data["status"] if "status" in data else None
+        self.__version = data["version"] if "version" in data else None
 
     @property
     def download_perc(self) -> int:
@@ -85,6 +108,21 @@ class SpeedLimitModeModel:
         self.__max_limit_mph = None
         self.__min_limit_mph = None
         self.__pin_code_set = None
+
+    def load(self, data: Dict) -> None:
+        """Load data from a JSON result."""
+
+        self.__active = data["active"] if "active" in data else None
+        self.__current_limit_mph = (
+            data["current_limit_mph"] if "current_limit_mph" in data else None
+        )
+        self.__max_limit_mph = (
+            data["max_limit_mph"] if "max_limit_mph" in data else None
+        )
+        self.__min_limit_mph = (
+            data["min_limit_mph"] if "min_limit_mph" in data else None
+        )
+        self.__pin_code_set = data["pin_code_set"] if "pin_code_set" in data else None
 
     @property
     def active(self) -> bool:
@@ -162,6 +200,113 @@ class VehicleStateModel:  # pylint: disable-msg=R0904
         self.__valet_mode = None
         self.__valet_pin_needed = None
         self.__vehicle_name = None
+
+    # pylint: disable-msg=too-many-statements
+    def load(self, data: Dict) -> None:
+        """Load data from a JSON result."""
+
+        self.__api_version = data["api_version"] if "api_version" in data else None
+        self.__autopark_state_v3 = (
+            data["autopark_state_v3"] if "autopark_state_v3" in data else None
+        )
+        self.__autopark_style = (
+            data["autopark_style"] if "autopark_style" in data else None
+        )
+        self.__calendar_supported = (
+            data["calendar_supported"] if "calendar_supported" in data else None
+        )
+        self.__car_version = data["car_version"] if "car_version" in data else None
+        self.__center_display_state = (
+            data["center_display_state"] if "center_display_state" in data else None
+        )
+        self.__df = data["df"] if "df" in data else None
+        self.__dr = data["dr"] if "dr" in data else None
+        self.__fd_window = data["fd_window"] if "fd_window" in data else None
+        self.__fp_window = data["fp_window"] if "fp_window" in data else None
+        self.__ft = data["ft"] if "ft" in data else None
+        self.__homelink_device_count = (
+            data["homelink_device_count"] if "homelink_device_count" in data else None
+        )
+        self.__homelink_nearby = (
+            data["homelink_nearby"] if "homelink_nearby" in data else None
+        )
+        self.__is_user_present = (
+            data["is_user_present"] if "is_user_present" in data else None
+        )
+        self.__last_autopark_error = (
+            data["last_autopark_error"] if "last_autopark_error" in data else None
+        )
+        self.__locked = data["locked"] if "locked" in data else None
+
+        if "media_state" in data:
+            media_state = MediaStateModel()
+            media_state.load(data["media_state"])
+            self.__media_state = media_state
+        else:
+            self.__media_state = None
+
+        self.__notifications_supported = (
+            data["notifications_supported"]
+            if "notifications_supported" in data
+            else None
+        )
+        self.__odometer = data["odometer"] if "odometer" in data else None
+        self.__parsed_calendar_supported = (
+            data["parsed_calendar_supported"]
+            if "parsed_calendar_supported" in data
+            else None
+        )
+        self.__pf = data["pf"] if "pf" in data else None
+        self.__pr = data["pr"] if "pr" in data else None
+        self.__rd_window = data["rd_window"] if "rd_window" in data else None
+        self.__remote_start = data["remote_start"] if "remote_start" in data else None
+        self.__remote_start_enabled = (
+            data["remote_start_enabled"] if "remote_start_enabled" in data else None
+        )
+        self.__remote_start_supported = (
+            data["remote_start_supported"] if "remote_start_supported" in data else None
+        )
+        self.__rp_window = data["rp_window"] if "rp_window" in data else None
+        self.__rt = data["rt"] if "rt" in data else None
+        self.__sentry_mode = data["sentry_mode"] if "sentry_mode" in data else None
+        self.__sentry_mode_available = (
+            data["sentry_mode_available"] if "sentry_mode_available" in data else None
+        )
+        self.__smart_summon_available = (
+            data["smart_summon_available"] if "smart_summon_available" in data else None
+        )
+
+        if "software_update" in data:
+            software_update = SoftwareUpdateModel()
+            software_update.load(data["software_update"])
+            self.__software_update = software_update
+        else:
+            self.__software_update = None
+
+        if "speed_limit_mode" in data:
+            speed_limit_mode = SpeedLimitModeModel()
+            speed_limit_mode.load(data["speed_limit_mode"])
+            self.__speed_limit_mode = speed_limit_mode
+        else:
+            self.__speed_limit_mode = None
+
+        self.__summon_standby_mode_enabled = (
+            data["summon_standby_mode_enabled"]
+            if "summon_standby_mode_enabled" in data
+            else None
+        )
+        self.__sun_roof_percent_open = (
+            data["sun_roof_percent_open"] if "sun_roof_percent_open" in data else None
+        )
+        self.__sun_roof_state = (
+            data["sun_roof_state"] if "sun_roof_state" in data else None
+        )
+        self.__timestamp = data["timestamp"] if "timestamp" in data else None
+        self.__valet_mode = data["valet_mode"] if "valet_mode" in data else None
+        self.__valet_pin_needed = (
+            data["valet_pin_needed"] if "valet_pin_needed" in data else None
+        )
+        self.__vehicle_name = data["vehicle_name"] if "vehicle_name" in data else None
 
     @property
     def api_version(self) -> int:

--- a/teslajsonpy/library/vehicle.py
+++ b/teslajsonpy/library/vehicle.py
@@ -1,0 +1,179 @@
+#  SPDX-License-Identifier: Apache-2.0
+"""Tesla vehicle."""
+
+from typing import Text
+
+from teslajsonpy.library.controller import Controller
+from teslajsonpy.library.model.vehicle import VehicleModel
+
+
+class Vehicle:
+    """Tesla vehicle view.
+
+    Use this class to manage the Tesla vehicle, checking state values, closing
+    trunk or locking doors, etc.
+
+    """
+
+    def __init__(self, controller: Controller, identifier: Text):
+        """Initialize the vehicle."""
+
+        self.__controller: Controller = controller
+        self.__model: VehicleModel = None
+
+        if controller is not None:
+            self.__model = controller.get_vehicle(identifier)
+        else:
+            self.__model = VehicleModel(identifier)
+
+    @property
+    def model(self) -> VehicleModel:
+        """Retrieve the model for this vehicle."""
+        return self.__model
+
+    #
+    # Door management
+    #
+
+    @property
+    def is_locked(self) -> bool:
+        """Return True if the doors are locked."""
+        return (
+            self.__model.vehicle_state.locked
+            if self.__model.vehicle_state is not None
+            else None
+        )
+
+    async def lock_doors(self) -> None:
+        """Lock the vehicle."""
+        self.__controller.door_lock(self.__model.id)
+
+    async def unlock_doors(self) -> None:
+        """Unlock the vehicle."""
+        self.__controller.door_unlock(self.__model.id)
+
+    #
+    # Trunk management
+    #
+
+    @property
+    def is_trunk_closed(self) -> bool:
+        """Return True if the rear trunk is closed."""
+        return (
+            self.__model.vehicle_state.rt == 0
+            if self.__model.vehicle_state is not None
+            else None
+        )
+
+    async def close_trunk(self) -> None:
+        """Close the rear trunk."""
+        if not self.is_trunk_closed:
+            self.__controller.actuate_trunk(self.__model.id)
+
+    async def open_trunk(self) -> None:
+        """Open the rear trunk."""
+        if self.is_trunk_closed:
+            self.__controller.actuate_trunk(self.__model.id)
+
+    #
+    # Frunk management
+    #
+
+    @property
+    def is_frunk_closed(self) -> bool:
+        """Return True if the front trunk (frunk) is closed."""
+        return (
+            self.__model.vehicle_state.ft == 0
+            if self.__model.vehicle_state is not None
+            else None
+        )
+
+    async def open_frunk(self) -> None:
+        """Open the front trunk (frunk)."""
+        if self.is_frunk_closed:
+            self.__controller.actuate_frunk(self.__model.id)
+
+    #
+    # HVAC management
+    #
+
+    @property
+    def inside_temperature(self) -> float:
+        """Return the inside temperature."""
+        return (
+            self.__model.climate_state.inside_temp
+            if self.__model.climate_state is not None
+            else None
+        )
+
+    @property
+    def outside_temperature(self) -> float:
+        """Return the outside temperature."""
+        return (
+            self.__model.climate_state.outside_temp
+            if self.__model.climate_state is not None
+            else None
+        )
+
+    async def start_climate(self) -> None:
+        """Start air conditionning system."""
+        self.__controller.climate_start(self.__model.id)
+
+    async def stop_climate(self) -> None:
+        """Stop air conditionning system."""
+        self.__controller.climate_stop(self.__model.id)
+
+    async def set_climate_temperature(self, temperature: float = 20) -> None:
+        """Set the target temperature of the air conditionning system."""
+        self.__controller.climate_set_temperature(self.__model.id, temperature)
+
+    #
+    # Sentry mode management
+    #
+
+    @property
+    def is_sentry_mode_available(self) -> bool:
+        """Return True if sentry mode is available for this vehicle."""
+        return (
+            self.__model.vehicle_state.sentry_mode_available
+            if self.__model.vehicle_state is not None
+            else None
+        )
+
+    @property
+    def is_sentry_mode_enabled(self) -> bool:
+        """Return True if sentry mode is available and enabled for this vehicle."""
+        return (
+            (
+                self.__model.vehicle_state.sentry_mode_available
+                & self.__model.vehicle_state.sentry_mode
+            )
+            if self.__model.vehicle_state is not None
+            else None
+        )
+
+    async def enable_sentry_mode(self) -> None:
+        """Enable the sentry mode."""
+        if self.__model.vehicle_state.sentry_mode_available:
+            self.__controller.sentry_mode_enable(self.__model.id)
+
+    async def disable_sentry_mode(self) -> None:
+        """Disable the sentry mode."""
+        if self.__model.vehicle_state.sentry_mode_available:
+            self.__controller.sentry_mode_disable(self.__model.id)
+
+    #
+    # Horn management
+    #
+
+    async def honk_horn(self) -> None:
+        """Honk the horn twice."""
+        self.__controller.honk_horn(self.__model.id)
+
+    #
+    # Lights management
+    #
+
+    async def flash_lights(self) -> None:
+        """Flash the lights."""
+        self.__controller.flash_lights(self.__model.id)

--- a/tests/ha/test_binary_sensor.py
+++ b/tests/ha/test_binary_sensor.py
@@ -102,20 +102,11 @@ def test_entity_registry_enabled_default():
     assert _sensor.entity_registry_enabled_default
 
 
-def test_update():
+@pytest.mark.asyncio
+async def test_update():
     """Test update()."""
 
     _sensor = BinarySensor("dummy")
 
     with pytest.raises(NotImplementedError):
-        _sensor.update()
-
-
-@pytest.mark.asyncio
-async def test_async_update():
-    """Test async_update()."""
-
-    _sensor = BinarySensor("dummy")
-
-    with pytest.raises(NotImplementedError):
-        await _sensor.async_update()
+        await _sensor.update()

--- a/tests/ha/test_binary_sensor.py
+++ b/tests/ha/test_binary_sensor.py
@@ -1,0 +1,121 @@
+"""Test Home Assistant BinarySensor."""
+
+import pytest
+
+from teslajsonpy.ha.binary_sensor import BinarySensor
+
+
+def test_is_on():
+    """Test is_on()."""
+
+    _sensor = BinarySensor("dummy")
+
+    assert not _sensor.is_on
+
+
+def test_assumed_state():
+    """Test assumed_state()."""
+
+    _sensor = BinarySensor("dummy")
+
+    assert not _sensor.assumed_state
+
+
+def test_available():
+    """Test available()."""
+
+    _sensor = BinarySensor("dummy")
+
+    assert _sensor.available
+
+
+def test_device_class():
+    """Test device_class()."""
+
+    _sensor = BinarySensor("dummy")
+
+    assert not _sensor.device_class is None
+    assert _sensor.device_class == "dummy"
+
+
+def test_device_state_attributes():
+    """Test device_state_attributes()."""
+
+    _sensor = BinarySensor("dummy")
+
+    assert _sensor.device_state_attributes is None
+
+
+def test_entity_picture():
+    """Test entity_picture()."""
+
+    _sensor = BinarySensor("dummy")
+
+    assert _sensor.entity_picture is None
+
+
+def test_name():
+    """Test name()."""
+
+    _sensor = BinarySensor("dummy")
+
+    assert _sensor.name is None
+
+
+def test_should_poll():
+    """Test should_poll()."""
+
+    _sensor = BinarySensor("dummy")
+
+    assert _sensor.should_poll
+
+
+def test_unique_id():
+    """Test unique_id()."""
+
+    _sensor = BinarySensor("dummy")
+
+    assert _sensor.unique_id is None
+
+
+def test_force_update():
+    """Test force_update()."""
+
+    _sensor = BinarySensor("dummy")
+
+    assert not _sensor.force_update
+
+
+def test_icon():
+    """Test icon()."""
+
+    _sensor = BinarySensor("dummy")
+
+    assert _sensor.icon is None
+
+
+def test_entity_registry_enabled_default():
+    """Test entity_registry_enabled_default()."""
+
+    _sensor = BinarySensor("dummy")
+
+    assert _sensor.entity_registry_enabled_default
+
+
+def test_update():
+    """Test update()."""
+
+    _sensor = BinarySensor("dummy")
+
+    with pytest.raises(NotImplementedError):
+        _sensor.update()
+
+
+@pytest.mark.asyncio
+async def test_async_update():
+    """Test async_update()."""
+
+    _sensor = BinarySensor("dummy")
+
+    with pytest.raises(NotImplementedError):
+        await _sensor.async_update()

--- a/tests/ha/test_charger_connection_sensor.py
+++ b/tests/ha/test_charger_connection_sensor.py
@@ -102,20 +102,11 @@ def test_entity_registry_enabled_default():
     assert _sensor.entity_registry_enabled_default
 
 
-def test_update():
+@pytest.mark.asyncio
+async def test_update():
     """Test update()."""
 
     _sensor = ChargerConnectionSensor()
 
     with pytest.raises(NotImplementedError):
-        _sensor.update()
-
-
-@pytest.mark.asyncio
-async def test_async_update():
-    """Test async_update()."""
-
-    _sensor = ChargerConnectionSensor()
-
-    with pytest.raises(NotImplementedError):
-        await _sensor.async_update()
+        await _sensor.update()

--- a/tests/ha/test_charger_connection_sensor.py
+++ b/tests/ha/test_charger_connection_sensor.py
@@ -1,0 +1,121 @@
+"""Test Home Assistant charger connection sensor."""
+
+import pytest
+
+from teslajsonpy.ha.binary_sensor import ChargerConnectionSensor, BinarySensorType
+
+
+def test_is_on():
+    """Test is_on()."""
+
+    _sensor = ChargerConnectionSensor()
+
+    assert not _sensor.is_on
+
+
+def test_assumed_state():
+    """Test assumed_state()."""
+
+    _sensor = ChargerConnectionSensor()
+
+    assert not _sensor.assumed_state
+
+
+def test_available():
+    """Test available()."""
+
+    _sensor = ChargerConnectionSensor()
+
+    assert _sensor.available
+
+
+def test_device_class():
+    """Test device_class()."""
+
+    _sensor = ChargerConnectionSensor()
+
+    assert not _sensor.device_class is None
+    assert _sensor.device_class == BinarySensorType.CONNECTIVITY
+
+
+def test_device_state_attributes():
+    """Test device_state_attributes()."""
+
+    _sensor = ChargerConnectionSensor()
+
+    assert _sensor.device_state_attributes is None
+
+
+def test_entity_picture():
+    """Test entity_picture()."""
+
+    _sensor = ChargerConnectionSensor()
+
+    assert _sensor.entity_picture is None
+
+
+def test_name():
+    """Test name()."""
+
+    _sensor = ChargerConnectionSensor()
+
+    assert _sensor.name is None
+
+
+def test_should_poll():
+    """Test should_poll()."""
+
+    _sensor = ChargerConnectionSensor()
+
+    assert _sensor.should_poll
+
+
+def test_unique_id():
+    """Test unique_id()."""
+
+    _sensor = ChargerConnectionSensor()
+
+    assert _sensor.unique_id is None
+
+
+def test_force_update():
+    """Test force_update()."""
+
+    _sensor = ChargerConnectionSensor()
+
+    assert not _sensor.force_update
+
+
+def test_icon():
+    """Test icon()."""
+
+    _sensor = ChargerConnectionSensor()
+
+    assert _sensor.icon is None
+
+
+def test_entity_registry_enabled_default():
+    """Test entity_registry_enabled_default()."""
+
+    _sensor = ChargerConnectionSensor()
+
+    assert _sensor.entity_registry_enabled_default
+
+
+def test_update():
+    """Test update()."""
+
+    _sensor = ChargerConnectionSensor()
+
+    with pytest.raises(NotImplementedError):
+        _sensor.update()
+
+
+@pytest.mark.asyncio
+async def test_async_update():
+    """Test async_update()."""
+
+    _sensor = ChargerConnectionSensor()
+
+    with pytest.raises(NotImplementedError):
+        await _sensor.async_update()

--- a/tests/ha/test_door_lock.py
+++ b/tests/ha/test_door_lock.py
@@ -1,0 +1,119 @@
+"""Test Home Assistant parking sensor."""
+
+import pytest
+
+from teslajsonpy.ha.lock import DoorLock
+
+
+def test_is_locked():
+    """Test is_locked()."""
+
+    _lock = DoorLock()
+
+    assert not _lock.is_locked
+
+
+def test_changed_by():
+    """Test changed_by()."""
+
+    _lock = DoorLock()
+
+    assert _lock.changed_by is None
+
+
+def test_assumed_state():
+    """Test assumed_state()."""
+
+    _lock = DoorLock()
+
+    assert not _lock.assumed_state
+
+
+def test_available():
+    """Test available()."""
+
+    _lock = DoorLock()
+
+    assert _lock.available
+
+
+def test_device_class():
+    """Test device_class()."""
+
+    _lock = DoorLock()
+
+    assert _lock.device_class is None
+
+
+def test_device_state_attributes():
+    """Test device_state_attributes()."""
+
+    _lock = DoorLock()
+
+    assert _lock.device_state_attributes is None
+
+
+def test_entity_picture():
+    """Test entity_picture()."""
+
+    _lock = DoorLock()
+
+    assert _lock.entity_picture is None
+
+
+def test_name():
+    """Test name()."""
+
+    _lock = DoorLock()
+
+    assert _lock.name is None
+
+
+def test_should_poll():
+    """Test should_poll()."""
+
+    _lock = DoorLock()
+
+    assert _lock.should_poll
+
+
+def test_unique_id():
+    """Test unique_id()."""
+
+    _lock = DoorLock()
+
+    assert _lock.unique_id is None
+
+
+def test_force_update():
+    """Test force_update()."""
+
+    _lock = DoorLock()
+
+    assert not _lock.force_update
+
+
+def test_icon():
+    """Test icon()."""
+
+    _lock = DoorLock()
+
+    assert _lock.icon is None
+
+
+def test_entity_registry_enabled_default():
+    """Test entity_registry_enabled_default()."""
+
+    _lock = DoorLock()
+
+    assert _lock.entity_registry_enabled_default
+
+
+@pytest.mark.asyncio
+async def test_update():
+    """Test update()."""
+
+    _lock = DoorLock()
+
+    with pytest.raises(NotImplementedError):
+        await _lock.update()

--- a/tests/ha/test_entity.py
+++ b/tests/ha/test_entity.py
@@ -1,0 +1,112 @@
+"""Test Home Assistant entity."""
+
+import pytest
+
+from teslajsonpy.ha.entity import Entity
+
+
+def test_assumed_state():
+    """Test assumed_state()."""
+
+    _entity = Entity()
+
+    assert not _entity.assumed_state
+
+
+def test_available():
+    """Test available()."""
+
+    _entity = Entity()
+
+    assert _entity.available
+
+
+def test_device_class():
+    """Test device_class()."""
+
+    _entity = Entity()
+
+    assert _entity.device_class is None
+
+
+def test_device_state_attributes():
+    """Test device_state_attributes()."""
+
+    _entity = Entity()
+
+    assert _entity.device_state_attributes is None
+
+
+def test_entity_picture():
+    """Test entity_picture()."""
+
+    _entity = Entity()
+
+    assert _entity.entity_picture is None
+
+
+def test_name():
+    """Test name()."""
+
+    _entity = Entity()
+
+    assert _entity.name is None
+
+
+def test_should_poll():
+    """Test should_poll()."""
+
+    _entity = Entity()
+
+    assert _entity.should_poll
+
+
+def test_unique_id():
+    """Test unique_id()."""
+
+    _entity = Entity()
+
+    assert _entity.unique_id is None
+
+
+def test_force_update():
+    """Test force_update()."""
+
+    _entity = Entity()
+
+    assert not _entity.force_update
+
+
+def test_icon():
+    """Test icon()."""
+
+    _entity = Entity()
+
+    assert _entity.icon is None
+
+
+def test_entity_registry_enabled_default():
+    """Test entity_registry_enabled_default()."""
+
+    _entity = Entity()
+
+    assert _entity.entity_registry_enabled_default
+
+
+def test_update():
+    """Test update()."""
+
+    _entity = Entity()
+
+    with pytest.raises(NotImplementedError):
+        _entity.update()
+
+
+@pytest.mark.asyncio
+async def test_async_update():
+    """Test async_update()."""
+
+    _entity = Entity()
+
+    with pytest.raises(NotImplementedError):
+        await _entity.async_update()

--- a/tests/ha/test_entity.py
+++ b/tests/ha/test_entity.py
@@ -93,20 +93,11 @@ def test_entity_registry_enabled_default():
     assert _entity.entity_registry_enabled_default
 
 
-def test_update():
+@pytest.mark.asyncio
+async def test_update():
     """Test update()."""
 
     _entity = Entity()
 
     with pytest.raises(NotImplementedError):
-        _entity.update()
-
-
-@pytest.mark.asyncio
-async def test_async_update():
-    """Test async_update()."""
-
-    _entity = Entity()
-
-    with pytest.raises(NotImplementedError):
-        await _entity.async_update()
+        await _entity.update()

--- a/tests/ha/test_frunk_lock.py
+++ b/tests/ha/test_frunk_lock.py
@@ -1,0 +1,119 @@
+"""Test Home Assistant parking sensor."""
+
+import pytest
+
+from teslajsonpy.ha.lock import FrunkLock
+
+
+def test_is_locked():
+    """Test is_locked()."""
+
+    _lock = FrunkLock()
+
+    assert not _lock.is_locked
+
+
+def test_changed_by():
+    """Test changed_by()."""
+
+    _lock = FrunkLock()
+
+    assert _lock.changed_by is None
+
+
+def test_assumed_state():
+    """Test assumed_state()."""
+
+    _lock = FrunkLock()
+
+    assert not _lock.assumed_state
+
+
+def test_available():
+    """Test available()."""
+
+    _lock = FrunkLock()
+
+    assert _lock.available
+
+
+def test_device_class():
+    """Test device_class()."""
+
+    _lock = FrunkLock()
+
+    assert _lock.device_class is None
+
+
+def test_device_state_attributes():
+    """Test device_state_attributes()."""
+
+    _lock = FrunkLock()
+
+    assert _lock.device_state_attributes is None
+
+
+def test_entity_picture():
+    """Test entity_picture()."""
+
+    _lock = FrunkLock()
+
+    assert _lock.entity_picture is None
+
+
+def test_name():
+    """Test name()."""
+
+    _lock = FrunkLock()
+
+    assert _lock.name is None
+
+
+def test_should_poll():
+    """Test should_poll()."""
+
+    _lock = FrunkLock()
+
+    assert _lock.should_poll
+
+
+def test_unique_id():
+    """Test unique_id()."""
+
+    _lock = FrunkLock()
+
+    assert _lock.unique_id is None
+
+
+def test_force_update():
+    """Test force_update()."""
+
+    _lock = FrunkLock()
+
+    assert not _lock.force_update
+
+
+def test_icon():
+    """Test icon()."""
+
+    _lock = FrunkLock()
+
+    assert _lock.icon is None
+
+
+def test_entity_registry_enabled_default():
+    """Test entity_registry_enabled_default()."""
+
+    _lock = FrunkLock()
+
+    assert _lock.entity_registry_enabled_default
+
+
+@pytest.mark.asyncio
+async def test_update():
+    """Test update()."""
+
+    _lock = FrunkLock()
+
+    with pytest.raises(NotImplementedError):
+        await _lock.update()

--- a/tests/ha/test_lock.py
+++ b/tests/ha/test_lock.py
@@ -1,0 +1,119 @@
+"""Test Home Assistant parking sensor."""
+
+import pytest
+
+from teslajsonpy.ha.lock import Lock
+
+
+def test_is_locked():
+    """Test is_locked()."""
+
+    _lock = Lock()
+
+    assert not _lock.is_locked
+
+
+def test_changed_by():
+    """Test changed_by()."""
+
+    _lock = Lock()
+
+    assert _lock.changed_by is None
+
+
+def test_assumed_state():
+    """Test assumed_state()."""
+
+    _lock = Lock()
+
+    assert not _lock.assumed_state
+
+
+def test_available():
+    """Test available()."""
+
+    _lock = Lock()
+
+    assert _lock.available
+
+
+def test_device_class():
+    """Test device_class()."""
+
+    _lock = Lock()
+
+    assert _lock.device_class is None
+
+
+def test_device_state_attributes():
+    """Test device_state_attributes()."""
+
+    _lock = Lock()
+
+    assert _lock.device_state_attributes is None
+
+
+def test_entity_picture():
+    """Test entity_picture()."""
+
+    _lock = Lock()
+
+    assert _lock.entity_picture is None
+
+
+def test_name():
+    """Test name()."""
+
+    _lock = Lock()
+
+    assert _lock.name is None
+
+
+def test_should_poll():
+    """Test should_poll()."""
+
+    _lock = Lock()
+
+    assert _lock.should_poll
+
+
+def test_unique_id():
+    """Test unique_id()."""
+
+    _lock = Lock()
+
+    assert _lock.unique_id is None
+
+
+def test_force_update():
+    """Test force_update()."""
+
+    _lock = Lock()
+
+    assert not _lock.force_update
+
+
+def test_icon():
+    """Test icon()."""
+
+    _lock = Lock()
+
+    assert _lock.icon is None
+
+
+def test_entity_registry_enabled_default():
+    """Test entity_registry_enabled_default()."""
+
+    _lock = Lock()
+
+    assert _lock.entity_registry_enabled_default
+
+
+@pytest.mark.asyncio
+async def test_update():
+    """Test update()."""
+
+    _lock = Lock()
+
+    with pytest.raises(NotImplementedError):
+        await _lock.update()

--- a/tests/ha/test_online_sensor.py
+++ b/tests/ha/test_online_sensor.py
@@ -1,0 +1,121 @@
+"""Test Home Assistant online sensor."""
+
+import pytest
+
+from teslajsonpy.ha.binary_sensor import OnlineSensor, BinarySensorType
+
+
+def test_is_on():
+    """Test is_on()."""
+
+    _sensor = OnlineSensor()
+
+    assert not _sensor.is_on
+
+
+def test_assumed_state():
+    """Test assumed_state()."""
+
+    _sensor = OnlineSensor()
+
+    assert not _sensor.assumed_state
+
+
+def test_available():
+    """Test available()."""
+
+    _sensor = OnlineSensor()
+
+    assert _sensor.available
+
+
+def test_device_class():
+    """Test device_class()."""
+
+    _sensor = OnlineSensor()
+
+    assert not _sensor.device_class is None
+    assert _sensor.device_class == BinarySensorType.CONNECTIVITY
+
+
+def test_device_state_attributes():
+    """Test device_state_attributes()."""
+
+    _sensor = OnlineSensor()
+
+    assert _sensor.device_state_attributes is None
+
+
+def test_entity_picture():
+    """Test entity_picture()."""
+
+    _sensor = OnlineSensor()
+
+    assert _sensor.entity_picture is None
+
+
+def test_name():
+    """Test name()."""
+
+    _sensor = OnlineSensor()
+
+    assert _sensor.name is None
+
+
+def test_should_poll():
+    """Test should_poll()."""
+
+    _sensor = OnlineSensor()
+
+    assert _sensor.should_poll
+
+
+def test_unique_id():
+    """Test unique_id()."""
+
+    _sensor = OnlineSensor()
+
+    assert _sensor.unique_id is None
+
+
+def test_force_update():
+    """Test force_update()."""
+
+    _sensor = OnlineSensor()
+
+    assert not _sensor.force_update
+
+
+def test_icon():
+    """Test icon()."""
+
+    _sensor = OnlineSensor()
+
+    assert _sensor.icon is None
+
+
+def test_entity_registry_enabled_default():
+    """Test entity_registry_enabled_default()."""
+
+    _sensor = OnlineSensor()
+
+    assert _sensor.entity_registry_enabled_default
+
+
+def test_update():
+    """Test update()."""
+
+    _sensor = OnlineSensor()
+
+    with pytest.raises(NotImplementedError):
+        _sensor.update()
+
+
+@pytest.mark.asyncio
+async def test_async_update():
+    """Test async_update()."""
+
+    _sensor = OnlineSensor()
+
+    with pytest.raises(NotImplementedError):
+        await _sensor.async_update()

--- a/tests/ha/test_online_sensor.py
+++ b/tests/ha/test_online_sensor.py
@@ -102,20 +102,11 @@ def test_entity_registry_enabled_default():
     assert _sensor.entity_registry_enabled_default
 
 
-def test_update():
+@pytest.mark.asyncio
+async def test_update():
     """Test update()."""
 
     _sensor = OnlineSensor()
 
     with pytest.raises(NotImplementedError):
-        _sensor.update()
-
-
-@pytest.mark.asyncio
-async def test_async_update():
-    """Test async_update()."""
-
-    _sensor = OnlineSensor()
-
-    with pytest.raises(NotImplementedError):
-        await _sensor.async_update()
+        await _sensor.update()

--- a/tests/ha/test_parking_sensor.py
+++ b/tests/ha/test_parking_sensor.py
@@ -102,20 +102,11 @@ def test_entity_registry_enabled_default():
     assert _sensor.entity_registry_enabled_default
 
 
-def test_update():
+@pytest.mark.asyncio
+async def test_update():
     """Test update()."""
 
     _sensor = ParkingSensor()
 
     with pytest.raises(NotImplementedError):
-        _sensor.update()
-
-
-@pytest.mark.asyncio
-async def test_async_update():
-    """Test async_update()."""
-
-    _sensor = ParkingSensor()
-
-    with pytest.raises(NotImplementedError):
-        await _sensor.async_update()
+        await _sensor.update()

--- a/tests/ha/test_parking_sensor.py
+++ b/tests/ha/test_parking_sensor.py
@@ -1,14 +1,14 @@
-"""Test Home Assistant binary sensor."""
+"""Test Home Assistant parking sensor."""
 
 import pytest
 
-from teslajsonpy.ha.binary_sensor import BinarySensor
+from teslajsonpy.ha.binary_sensor import ParkingSensor, BinarySensorType
 
 
 def test_is_on():
     """Test is_on()."""
 
-    _sensor = BinarySensor("dummy")
+    _sensor = ParkingSensor()
 
     assert not _sensor.is_on
 
@@ -16,7 +16,7 @@ def test_is_on():
 def test_assumed_state():
     """Test assumed_state()."""
 
-    _sensor = BinarySensor("dummy")
+    _sensor = ParkingSensor()
 
     assert not _sensor.assumed_state
 
@@ -24,7 +24,7 @@ def test_assumed_state():
 def test_available():
     """Test available()."""
 
-    _sensor = BinarySensor("dummy")
+    _sensor = ParkingSensor()
 
     assert _sensor.available
 
@@ -32,16 +32,16 @@ def test_available():
 def test_device_class():
     """Test device_class()."""
 
-    _sensor = BinarySensor("dummy")
+    _sensor = ParkingSensor()
 
     assert not _sensor.device_class is None
-    assert _sensor.device_class == "dummy"
+    assert _sensor.device_class == BinarySensorType.POWER
 
 
 def test_device_state_attributes():
     """Test device_state_attributes()."""
 
-    _sensor = BinarySensor("dummy")
+    _sensor = ParkingSensor()
 
     assert _sensor.device_state_attributes is None
 
@@ -49,7 +49,7 @@ def test_device_state_attributes():
 def test_entity_picture():
     """Test entity_picture()."""
 
-    _sensor = BinarySensor("dummy")
+    _sensor = ParkingSensor()
 
     assert _sensor.entity_picture is None
 
@@ -57,7 +57,7 @@ def test_entity_picture():
 def test_name():
     """Test name()."""
 
-    _sensor = BinarySensor("dummy")
+    _sensor = ParkingSensor()
 
     assert _sensor.name is None
 
@@ -65,7 +65,7 @@ def test_name():
 def test_should_poll():
     """Test should_poll()."""
 
-    _sensor = BinarySensor("dummy")
+    _sensor = ParkingSensor()
 
     assert _sensor.should_poll
 
@@ -73,7 +73,7 @@ def test_should_poll():
 def test_unique_id():
     """Test unique_id()."""
 
-    _sensor = BinarySensor("dummy")
+    _sensor = ParkingSensor()
 
     assert _sensor.unique_id is None
 
@@ -81,7 +81,7 @@ def test_unique_id():
 def test_force_update():
     """Test force_update()."""
 
-    _sensor = BinarySensor("dummy")
+    _sensor = ParkingSensor()
 
     assert not _sensor.force_update
 
@@ -89,7 +89,7 @@ def test_force_update():
 def test_icon():
     """Test icon()."""
 
-    _sensor = BinarySensor("dummy")
+    _sensor = ParkingSensor()
 
     assert _sensor.icon is None
 
@@ -97,7 +97,7 @@ def test_icon():
 def test_entity_registry_enabled_default():
     """Test entity_registry_enabled_default()."""
 
-    _sensor = BinarySensor("dummy")
+    _sensor = ParkingSensor()
 
     assert _sensor.entity_registry_enabled_default
 
@@ -105,7 +105,7 @@ def test_entity_registry_enabled_default():
 def test_update():
     """Test update()."""
 
-    _sensor = BinarySensor("dummy")
+    _sensor = ParkingSensor()
 
     with pytest.raises(NotImplementedError):
         _sensor.update()
@@ -115,7 +115,7 @@ def test_update():
 async def test_async_update():
     """Test async_update()."""
 
-    _sensor = BinarySensor("dummy")
+    _sensor = ParkingSensor()
 
     with pytest.raises(NotImplementedError):
         await _sensor.async_update()

--- a/tests/ha/test_trunk_lock.py
+++ b/tests/ha/test_trunk_lock.py
@@ -1,0 +1,119 @@
+"""Test Home Assistant parking sensor."""
+
+import pytest
+
+from teslajsonpy.ha.lock import TrunkLock
+
+
+def test_is_locked():
+    """Test is_locked()."""
+
+    _lock = TrunkLock()
+
+    assert not _lock.is_locked
+
+
+def test_changed_by():
+    """Test changed_by()."""
+
+    _lock = TrunkLock()
+
+    assert _lock.changed_by is None
+
+
+def test_assumed_state():
+    """Test assumed_state()."""
+
+    _lock = TrunkLock()
+
+    assert not _lock.assumed_state
+
+
+def test_available():
+    """Test available()."""
+
+    _lock = TrunkLock()
+
+    assert _lock.available
+
+
+def test_device_class():
+    """Test device_class()."""
+
+    _lock = TrunkLock()
+
+    assert _lock.device_class is None
+
+
+def test_device_state_attributes():
+    """Test device_state_attributes()."""
+
+    _lock = TrunkLock()
+
+    assert _lock.device_state_attributes is None
+
+
+def test_entity_picture():
+    """Test entity_picture()."""
+
+    _lock = TrunkLock()
+
+    assert _lock.entity_picture is None
+
+
+def test_name():
+    """Test name()."""
+
+    _lock = TrunkLock()
+
+    assert _lock.name is None
+
+
+def test_should_poll():
+    """Test should_poll()."""
+
+    _lock = TrunkLock()
+
+    assert _lock.should_poll
+
+
+def test_unique_id():
+    """Test unique_id()."""
+
+    _lock = TrunkLock()
+
+    assert _lock.unique_id is None
+
+
+def test_force_update():
+    """Test force_update()."""
+
+    _lock = TrunkLock()
+
+    assert not _lock.force_update
+
+
+def test_icon():
+    """Test icon()."""
+
+    _lock = TrunkLock()
+
+    assert _lock.icon is None
+
+
+def test_entity_registry_enabled_default():
+    """Test entity_registry_enabled_default()."""
+
+    _lock = TrunkLock()
+
+    assert _lock.entity_registry_enabled_default
+
+
+@pytest.mark.asyncio
+async def test_update():
+    """Test update()."""
+
+    _lock = TrunkLock()
+
+    with pytest.raises(NotImplementedError):
+        await _lock.update()

--- a/tests/library/test_connection.py
+++ b/tests/library/test_connection.py
@@ -1,0 +1,69 @@
+"""Test HTTP connection."""
+
+import pytest
+
+from teslajsonpy.library.connection import Connection
+
+from tests.mock.connection_mock import ConnectionMock
+
+
+@pytest.mark.asyncio
+async def test_get():
+    """Test get()."""
+
+    _connection = Connection()
+
+    with pytest.raises(NotImplementedError):
+        await _connection.get("http://localhost:8000/dummy")
+
+
+@pytest.mark.asyncio
+async def test_get_mocked(monkeypatch):
+    """Test get() with mock."""
+
+    ConnectionMock(monkeypatch)
+    _connection = Connection()
+
+    assert _connection.get("http://localhost:8000/dummy") is not None
+
+
+@pytest.mark.asyncio
+async def test_post():
+    """Test post()."""
+
+    _connection = Connection()
+
+    with pytest.raises(NotImplementedError):
+        await _connection.post("http://localhost:8000/dummy", {"dummy": "test"})
+
+
+@pytest.mark.asyncio
+async def test_post_mocked(monkeypatch):
+    """Test post() with mock."""
+
+    ConnectionMock(monkeypatch)
+    _connection = Connection()
+
+    assert (
+        _connection.post("http://localhost:8000/dummy", {"dummy": "test"}) is not None
+    )
+
+
+@pytest.mark.asyncio
+async def test_request():
+    """Test request()."""
+
+    _connection = Connection()
+
+    with pytest.raises(NotImplementedError):
+        await _connection.request("http://localhost:8000/dummy", "get")
+
+
+@pytest.mark.asyncio
+async def test_request_mocked(monkeypatch):
+    """Test request() with mock."""
+
+    ConnectionMock(monkeypatch)
+    _connection = Connection()
+
+    assert _connection.request("http://localhost:8000/dummy", "get") is not None

--- a/tests/library/test_controller.py
+++ b/tests/library/test_controller.py
@@ -1,0 +1,616 @@
+"""Test controller."""
+
+import pytest
+
+from teslajsonpy.library.controller import Controller
+from teslajsonpy.library.exceptions import UnknownVehicleException
+
+from teslajsonpy.library.model.vehicle import VehicleModel
+
+from tests.mock.api_mock import ApiMock
+from tests.mock.connection_mock import ConnectionMock
+
+
+def test_init():
+    """Test initialization."""
+
+    controller = Controller()
+
+    assert controller is not None
+    assert controller.vehicles is not None
+
+
+@pytest.mark.asyncio
+async def test_get_tokens(monkeypatch):
+    """Test get_tokens()."""
+
+    ApiMock(monkeypatch)
+
+    controller = Controller()
+
+    tokens = controller.get_tokens()
+    assert tokens is None
+
+    await controller.connect("elon@teslamotors.com", "edisonsux")
+    tokens = controller.get_tokens()
+
+    assert tokens is not None
+    assert len(tokens) == 2
+    assert tokens[0] == "cba321"
+    assert tokens[1] == "abc123"
+
+
+@pytest.mark.asyncio
+async def test_get_expiration(monkeypatch):
+    """Test get_expiration()."""
+
+    ApiMock(monkeypatch)
+
+    controller = Controller()
+
+    await controller.connect("elon@teslamotors.com", "edisonsux")
+    assert controller.get_expiration() == 3888000
+
+
+def test_add_vehicle():
+    """Test add_vehicle()."""
+
+    controller = Controller()
+
+    vehicle1 = VehicleModel(123)
+    controller.add_vehicle(vehicle1)
+
+    assert 123 in controller.vehicles.keys()
+    assert len(controller.vehicles) == 1
+
+    # Only 1
+    controller.add_vehicle(vehicle1)
+
+    assert 123 in controller.vehicles.keys()
+    assert len(controller.vehicles) == 1
+
+    vehicle2 = VehicleModel(456)
+    controller.add_vehicle(vehicle2)
+
+    assert 123 in controller.vehicles.keys()
+    assert 456 in controller.vehicles.keys()
+    assert len(controller.vehicles) == 2
+
+
+def test_add_vehicle_none():
+    """Test add_vehicle() with a None value."""
+
+    controller = Controller()
+
+    controller.add_vehicle(None)
+
+    assert len(controller.vehicles) == 0
+
+
+def test_get_vehicle():
+    """Test get_vehicle()."""
+
+    controller = Controller()
+
+    vehicle1 = VehicleModel(123)
+    controller.add_vehicle(vehicle1)
+
+    result = controller.get_vehicle(123)
+    assert result.id == 123
+
+
+@pytest.mark.asyncio
+async def test_refresh_vehicles(monkeypatch):
+    """Test refresh_vehicles()."""
+
+    ApiMock(monkeypatch)
+
+    controller = Controller()
+
+    await controller.refresh_vehicles()
+
+    assert controller.vehicles is not None
+    assert len(controller.vehicles) == 1
+
+    # Unknown ID
+    vehicle = controller.get_vehicle(123)
+    assert vehicle is None
+
+    # Default mock
+    vehicle = controller.get_vehicle(12345678901234567)
+    assert vehicle is not None
+    assert vehicle.id == 12345678901234567
+    assert vehicle.display_name == "Nikola 2.0"
+
+
+@pytest.mark.asyncio
+async def test_fetch_vehicle_data(monkeypatch):
+    """Test _fetch_vehicle_data()."""
+
+    ApiMock(monkeypatch)
+
+    controller = Controller()
+    identifier = 12345678901234567
+
+    # pylint: disable-msg=protected-access
+    await controller._fetch_vehicle_data(identifier)
+
+    assert len(controller.vehicles) == 1
+
+    # Unknown ID
+    vehicle = controller.get_vehicle(123)
+    assert vehicle is None
+
+    # Default mock
+    vehicle = controller.get_vehicle(identifier)
+    assert vehicle is not None
+    assert vehicle.id == 12345678901234567
+    assert vehicle.display_name == "Nikola 2.0"
+
+
+@pytest.mark.asyncio
+async def test_lock_doors(monkeypatch):
+    """Test lock_doors()."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+    vehicle1 = VehicleModel(123)
+    controller.add_vehicle(vehicle1)
+
+    await controller.lock_doors(123)
+    assert True
+
+
+@pytest.mark.asyncio
+async def test_lock_doors_unknown_vehicle(monkeypatch):
+    """Test lock_doors() for an unknown vehicle."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+
+    with pytest.raises(UnknownVehicleException):
+        await controller.lock_doors(12345)
+
+
+@pytest.mark.asyncio
+async def test_unlock_doors(monkeypatch):
+    """Test unlock_doors()."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+    vehicle1 = VehicleModel(123)
+    controller.add_vehicle(vehicle1)
+
+    await controller.unlock_doors(123)
+    assert True
+
+
+@pytest.mark.asyncio
+async def test_unlock_doors_unknown_vehicle(monkeypatch):
+    """Test unlock_doors() for an unknown vehicle."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+
+    with pytest.raises(UnknownVehicleException):
+        await controller.unlock_doors(12345)
+
+
+@pytest.mark.asyncio
+async def test_actuate_trunk(monkeypatch):
+    """Test actuate_trunk()."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+    vehicle1 = VehicleModel(123)
+    controller.add_vehicle(vehicle1)
+
+    await controller.actuate_trunk(123)
+    assert True
+
+
+@pytest.mark.asyncio
+async def test_actuate_trunk_unknown_vehicle(monkeypatch):
+    """Test actuate_trunk()."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+
+    with pytest.raises(UnknownVehicleException):
+        await controller.actuate_trunk(12345)
+
+
+@pytest.mark.asyncio
+async def test_actuate_frunk(monkeypatch):
+    """Test actuate_frunk()."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+    vehicle1 = VehicleModel(123)
+    controller.add_vehicle(vehicle1)
+
+    await controller.actuate_frunk(123)
+    assert True
+
+
+@pytest.mark.asyncio
+async def test_actuate_frunk_unknown_vehicle(monkeypatch):
+    """Test actuate_frunk() for an unknown vehicle."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+
+    with pytest.raises(UnknownVehicleException):
+        await controller.actuate_frunk(12345)
+
+
+@pytest.mark.asyncio
+async def test_open_charge_port(monkeypatch):
+    """Test open_charge_port()."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+    vehicle1 = VehicleModel(123)
+    controller.add_vehicle(vehicle1)
+
+    await controller.open_charge_port(123)
+    assert True
+
+
+@pytest.mark.asyncio
+async def test_open_charge_port_unknown_vehicle(monkeypatch):
+    """Test open_charge_port() for an unknown vehicle."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+
+    with pytest.raises(UnknownVehicleException):
+        await controller.open_charge_port(12345)
+
+
+@pytest.mark.asyncio
+async def test_close_charge_port(monkeypatch):
+    """Test close_charge_port()."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+    vehicle1 = VehicleModel(123)
+    controller.add_vehicle(vehicle1)
+
+    await controller.close_charge_port(123)
+    assert True
+
+
+@pytest.mark.asyncio
+async def test_close_charge_port_unknown_vehicle(monkeypatch):
+    """Test close_charge_port() for an unknown vehicle."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+
+    with pytest.raises(UnknownVehicleException):
+        await controller.close_charge_port(12345)
+
+
+@pytest.mark.asyncio
+async def test_start_charge(monkeypatch):
+    """Test start_charge()."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+    vehicle1 = VehicleModel(123)
+    controller.add_vehicle(vehicle1)
+
+    await controller.start_charge(123)
+    assert True
+
+
+@pytest.mark.asyncio
+async def test_start_charge_unknown_vehicle(monkeypatch):
+    """Test start_charge() for an unknown vehicle."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+
+    with pytest.raises(UnknownVehicleException):
+        await controller.start_charge(12345)
+
+
+@pytest.mark.asyncio
+async def test_stop_charge(monkeypatch):
+    """Test stop_charge()."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+    vehicle1 = VehicleModel(123)
+    controller.add_vehicle(vehicle1)
+
+    await controller.stop_charge(123)
+    assert True
+
+
+@pytest.mark.asyncio
+async def test_stop_charge_unknown_vehicle(monkeypatch):
+    """Test stop_charge() for an unknown vehicle."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+
+    with pytest.raises(UnknownVehicleException):
+        await controller.stop_charge(12345)
+
+
+@pytest.mark.asyncio
+async def test_set_charge_limit(monkeypatch):
+    """Test set_charge_limit()."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+    vehicle1 = VehicleModel(123)
+    controller.add_vehicle(vehicle1)
+
+    await controller.set_charge_limit(123, 66)
+    assert True
+
+
+@pytest.mark.asyncio
+async def test_set_charge_limit_unknown_vehicle(monkeypatch):
+    """Test set_charge_limit() for an unknown vehicle."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+
+    with pytest.raises(UnknownVehicleException):
+        await controller.set_charge_limit(12345, 66)
+
+
+@pytest.mark.asyncio
+async def test_set_charge_limit_standard(monkeypatch):
+    """Test set_charge_limit_standard()."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+    vehicle1 = VehicleModel(123)
+    controller.add_vehicle(vehicle1)
+
+    await controller.set_charge_limit_standard(123)
+    assert True
+
+
+@pytest.mark.asyncio
+async def test_set_charge_limit_standard_unknown_vehicle(monkeypatch):
+    """Test set_charge_limit_standard() for an unknown vehicle."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+
+    with pytest.raises(UnknownVehicleException):
+        await controller.set_charge_limit_standard(12345)
+
+
+@pytest.mark.asyncio
+async def test_set_charge_limit_max_range(monkeypatch):
+    """Test set_charge_limit_max_range()."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+    vehicle1 = VehicleModel(123)
+    controller.add_vehicle(vehicle1)
+
+    await controller.set_charge_limit_max_range(123)
+    assert True
+
+
+@pytest.mark.asyncio
+async def test_set_charge_limit_max_range_unknown_vehicle(monkeypatch):
+    """Test set_charge_limit_max_range() for an unknown vehicle."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+
+    with pytest.raises(UnknownVehicleException):
+        await controller.set_charge_limit_max_range(12345)
+
+
+@pytest.mark.asyncio
+async def test_start_climate(monkeypatch):
+    """Test start_climate()."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+    vehicle1 = VehicleModel(123)
+    controller.add_vehicle(vehicle1)
+
+    await controller.start_climate(123)
+    assert True
+
+
+@pytest.mark.asyncio
+async def test_start_climate_unknown_vehicle(monkeypatch):
+    """Test start_climate() for an unknown vehicle."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+
+    with pytest.raises(UnknownVehicleException):
+        await controller.start_climate(12345)
+
+
+@pytest.mark.asyncio
+async def test_stop_climate(monkeypatch):
+    """Test stop_climate()."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+    vehicle1 = VehicleModel(123)
+    controller.add_vehicle(vehicle1)
+
+    await controller.stop_climate(123)
+    assert True
+
+
+@pytest.mark.asyncio
+async def test_stop_climate_unknown_vehicle(monkeypatch):
+    """Test stop_climate() for an unknown vehicle."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+
+    with pytest.raises(UnknownVehicleException):
+        await controller.stop_climate(12345)
+
+
+@pytest.mark.asyncio
+async def test_set_climate_temperature(monkeypatch):
+    """Test set_climate_temperature()."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+    vehicle1 = VehicleModel(123)
+    controller.add_vehicle(vehicle1)
+
+    await controller.set_climate_temperature(123, 22)
+    assert True
+
+
+@pytest.mark.asyncio
+async def test_set_climate_temperature_unknown_vehicle(monkeypatch):
+    """Test set_climate_temperature() for an unknown vehicle."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+
+    with pytest.raises(UnknownVehicleException):
+        await controller.set_climate_temperature(12345, 22)
+
+
+@pytest.mark.asyncio
+async def test_enable_sentry_mode(monkeypatch):
+    """Test enable_sentry_mode()."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+    vehicle1 = VehicleModel(123)
+    controller.add_vehicle(vehicle1)
+
+    await controller.enable_sentry_mode(123)
+    assert True
+
+
+@pytest.mark.asyncio
+async def test_enable_sentry_mode_unknown_vehicle(monkeypatch):
+    """Test enable_sentry_mode() for an unknown vehicle."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+
+    with pytest.raises(UnknownVehicleException):
+        await controller.enable_sentry_mode(12345)
+
+
+@pytest.mark.asyncio
+async def test_disable_sentry_mode(monkeypatch):
+    """Test disable_sentry_mode()."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+    vehicle1 = VehicleModel(123)
+    controller.add_vehicle(vehicle1)
+
+    await controller.disable_sentry_mode(123)
+    assert True
+
+
+@pytest.mark.asyncio
+async def test_disable_sentry_mode_unknown_vehicle(monkeypatch):
+    """Test disable_sentry_mode() for an unknown vehicle."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+
+    with pytest.raises(UnknownVehicleException):
+        await controller.disable_sentry_mode(12345)
+
+
+@pytest.mark.asyncio
+async def test_honk_horn(monkeypatch):
+    """Test honk_horn()."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+    vehicle1 = VehicleModel(123)
+    controller.add_vehicle(vehicle1)
+
+    await controller.honk_horn(123)
+    assert True
+
+
+@pytest.mark.asyncio
+async def test_honk_horn_unknown_vehicle(monkeypatch):
+    """Test honk_horn() for an unknown vehicle."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+
+    with pytest.raises(UnknownVehicleException):
+        await controller.honk_horn(12345)
+
+
+@pytest.mark.asyncio
+async def test_flash_lights(monkeypatch):
+    """Test flash_lights()."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+    vehicle1 = VehicleModel(123)
+    controller.add_vehicle(vehicle1)
+
+    await controller.flash_lights(123)
+    assert True
+
+
+@pytest.mark.asyncio
+async def test_flash_lights_unknown_vehicle(monkeypatch):
+    """Test flash_lights() for an unknown vehicle."""
+
+    ConnectionMock(monkeypatch)
+
+    controller = Controller()
+
+    with pytest.raises(UnknownVehicleException):
+        await controller.flash_lights(12345)

--- a/tests/library/test_mock_values.py
+++ b/tests/library/test_mock_values.py
@@ -1,0 +1,213 @@
+"""Test the mock values using the controller."""
+
+import pytest
+
+from teslajsonpy.library.controller import Controller
+
+from tests.mock.api_mock import ApiMock
+
+
+# pylint: disable-msg=too-many-statements
+@pytest.mark.asyncio
+async def test_fetch_vehicle_data_full(monkeypatch):
+    """Test _fetch_vehicle_data() and check all mock values (coverage)."""
+
+    ApiMock(monkeypatch)
+
+    controller = Controller()
+    identifier = 12345678901234567
+
+    # pylint: disable-msg=protected-access
+    await controller._fetch_vehicle_data(identifier)
+
+    # Default mock
+    vehicle = controller.get_vehicle(identifier)
+    assert vehicle is not None
+
+    assert vehicle.id == 12345678901234567
+    assert vehicle.user_id == 123
+    assert vehicle.vehicle_id == 1234567890
+    assert vehicle.vin == "5YJSA11111111111"
+    assert vehicle.display_name == "Nikola 2.0"
+    assert vehicle.option_codes is not None
+    assert vehicle.color is None
+    assert vehicle.tokens == ["abcdef1234567890", "1234567890abcdef"]
+    assert vehicle.state == "online"
+    assert not vehicle.in_service
+    assert vehicle.id_s == "12345678901234567"
+    assert vehicle.calendar_enabled
+    assert vehicle.api_version == 7
+    assert vehicle.backseat_token is None
+    assert vehicle.backseat_token_updated_at is None
+
+    assert vehicle.drive_state.gps_as_of == 1538363883
+    assert vehicle.drive_state.heading == 5
+    assert vehicle.drive_state.latitude == 33.111111
+    assert vehicle.drive_state.longitude == -88.111111
+    assert vehicle.drive_state.native_latitude == 33.111111
+    assert vehicle.drive_state.native_location_supported == 1
+    assert vehicle.drive_state.native_longitude == -88.111111
+    assert vehicle.drive_state.native_type == "wgs"
+    assert vehicle.drive_state.power == 0
+    assert vehicle.drive_state.shift_state is None
+    assert vehicle.drive_state.speed is None
+    assert vehicle.drive_state.timestamp == 1538364666096
+
+    assert not vehicle.climate_state.battery_heater
+    assert not vehicle.climate_state.battery_heater_no_power
+    assert vehicle.climate_state.climate_keeper_mode == "dog"
+    assert vehicle.climate_state.defrost_mode == 0
+    assert vehicle.climate_state.driver_temp_setting == 21.6
+    assert vehicle.climate_state.fan_status == 0
+    assert vehicle.climate_state.inside_temp == 18.5
+    assert vehicle.climate_state.is_auto_conditioning_on is None
+    assert not vehicle.climate_state.is_climate_on
+    assert not vehicle.climate_state.is_front_defroster_on
+    assert not vehicle.climate_state.is_preconditioning
+    assert not vehicle.climate_state.is_rear_defroster_on
+    assert vehicle.climate_state.left_temp_direction is None
+    assert vehicle.climate_state.max_avail_temp == 28.0
+    assert vehicle.climate_state.min_avail_temp == 15.0
+    assert vehicle.climate_state.outside_temp == 12.0
+    assert vehicle.climate_state.passenger_temp_setting == 21.6
+    assert vehicle.climate_state.remote_heater_control_enabled
+    assert vehicle.climate_state.right_temp_direction is None
+    assert vehicle.climate_state.seat_heater_left == 3
+    assert vehicle.climate_state.seat_heater_rear_center == 0
+    assert vehicle.climate_state.seat_heater_rear_left == 1
+    assert vehicle.climate_state.seat_heater_rear_left_back == 0
+    assert vehicle.climate_state.seat_heater_rear_right == 1
+    assert vehicle.climate_state.seat_heater_rear_right_back == 0
+    assert vehicle.climate_state.seat_heater_right == 2
+    assert not vehicle.climate_state.side_mirror_heaters
+    assert not vehicle.climate_state.steering_wheel_heater
+    assert vehicle.climate_state.timestamp == 1543186971731
+    assert not vehicle.climate_state.wiper_blade_heater
+
+    assert not vehicle.charge_state.battery_heater_on
+    assert vehicle.charge_state.battery_level == 64
+    assert vehicle.charge_state.battery_range == 167.96
+    assert vehicle.charge_state.charge_current_request == 48
+    assert vehicle.charge_state.charge_current_request_max == 48
+    assert vehicle.charge_state.charge_enable_request
+    assert vehicle.charge_state.charge_energy_added == 12.41
+    assert vehicle.charge_state.charge_limit_soc == 90
+    assert vehicle.charge_state.charge_limit_soc_max == 100
+    assert vehicle.charge_state.charge_limit_soc_min == 50
+    assert vehicle.charge_state.charge_limit_soc_std == 90
+    assert vehicle.charge_state.charge_miles_added_ideal == 50.0
+    assert vehicle.charge_state.charge_miles_added_rated == 40.0
+    assert not vehicle.charge_state.charge_port_cold_weather_mode
+    assert not vehicle.charge_state.charge_port_door_open
+    assert vehicle.charge_state.charge_port_latch == "Engaged"
+    assert vehicle.charge_state.charge_rate == 0.0
+    assert not vehicle.charge_state.charge_to_max_range
+    assert vehicle.charge_state.charger_actual_current == 0
+    assert vehicle.charge_state.charger_phases is None
+    assert vehicle.charge_state.charger_pilot_current == 48
+    assert vehicle.charge_state.charger_power == 0
+    assert vehicle.charge_state.charger_voltage == 0
+    assert vehicle.charge_state.charging_state == "Disconnected"
+    assert vehicle.charge_state.conn_charge_cable == "<invalid>"
+    assert vehicle.charge_state.est_battery_range == 118.38
+    assert vehicle.charge_state.fast_charger_brand == "<invalid>"
+    assert not vehicle.charge_state.fast_charger_present
+    assert vehicle.charge_state.fast_charger_type == "<invalid>"
+    assert vehicle.charge_state.ideal_battery_range == 209.95
+    assert not vehicle.charge_state.managed_charging_active
+    assert vehicle.charge_state.managed_charging_start_time is None
+    assert not vehicle.charge_state.managed_charging_user_canceled
+    assert vehicle.charge_state.max_range_charge_counter == 0
+    assert vehicle.charge_state.minutes_to_full_charge == 0
+    assert not vehicle.charge_state.not_enough_power_to_heat
+    assert not vehicle.charge_state.scheduled_charging_pending
+    assert vehicle.charge_state.scheduled_charging_start_time is None
+    assert vehicle.charge_state.time_to_full_charge == 0.0
+    assert vehicle.charge_state.timestamp == 1543186971727
+    assert not vehicle.charge_state.trip_charging
+    assert vehicle.charge_state.usable_battery_level == 64
+    assert vehicle.charge_state.user_charge_enable_request is None
+
+    assert not vehicle.gui_settings.gui_24_hour_time
+    assert vehicle.gui_settings.gui_charge_rate_units == "mi/hr"
+    assert vehicle.gui_settings.gui_distance_units == "mi/hr"
+    assert vehicle.gui_settings.gui_range_display == "Rated"
+    assert vehicle.gui_settings.gui_temperature_units == "F"
+    assert vehicle.gui_settings.show_range_units
+    assert vehicle.gui_settings.timestamp == 1543186971728
+
+    assert vehicle.vehicle_state.api_version == 7
+    assert vehicle.vehicle_state.autopark_state_v3 == "standby"
+    assert vehicle.vehicle_state.autopark_style == "standard"
+    assert vehicle.vehicle_state.calendar_supported
+    assert vehicle.vehicle_state.car_version == "2019.40.2.1 38f55d9f9205"
+    assert vehicle.vehicle_state.center_display_state == 0
+    assert vehicle.vehicle_state.df == 0
+    assert vehicle.vehicle_state.dr == 0
+    assert vehicle.vehicle_state.fd_window == 0
+    assert vehicle.vehicle_state.fp_window == 0
+    assert vehicle.vehicle_state.ft == 0
+    assert vehicle.vehicle_state.homelink_device_count == 0
+    assert vehicle.vehicle_state.homelink_nearby
+    assert not vehicle.vehicle_state.is_user_present
+    assert vehicle.vehicle_state.last_autopark_error == "no_error"
+    assert vehicle.vehicle_state.locked
+    assert vehicle.vehicle_state.notifications_supported
+    assert vehicle.vehicle_state.odometer == 33561.422505
+    assert vehicle.vehicle_state.parsed_calendar_supported
+    assert vehicle.vehicle_state.pf == 0
+    assert vehicle.vehicle_state.pr == 0
+    assert vehicle.vehicle_state.rd_window == 0
+    assert not vehicle.vehicle_state.remote_start
+    assert vehicle.vehicle_state.remote_start_enabled
+    assert vehicle.vehicle_state.remote_start_supported
+    assert vehicle.vehicle_state.rp_window == 0
+    assert vehicle.vehicle_state.rt == 0
+    assert vehicle.vehicle_state.sentry_mode
+    assert vehicle.vehicle_state.sentry_mode_available
+    assert vehicle.vehicle_state.smart_summon_available
+    assert vehicle.vehicle_state.summon_standby_mode_enabled
+    assert vehicle.vehicle_state.sun_roof_percent_open == 0
+    assert vehicle.vehicle_state.sun_roof_state == "unknown"
+    assert vehicle.vehicle_state.timestamp == 1538364666096
+    assert not vehicle.vehicle_state.valet_mode
+    assert vehicle.vehicle_state.valet_pin_needed
+    assert vehicle.vehicle_state.vehicle_name == "Nikola 2.0"
+    assert vehicle.vehicle_state.media_state.remote_control_enabled
+    assert vehicle.vehicle_state.software_update.download_perc == 100
+    assert vehicle.vehicle_state.software_update.expected_duration_sec == 2700
+    assert vehicle.vehicle_state.software_update.install_perc == 10
+    assert vehicle.vehicle_state.software_update.scheduled_time_ms == 1575689678432
+    assert vehicle.vehicle_state.software_update.status == "scheduled"
+    assert vehicle.vehicle_state.software_update.version == "2019.40.2.1"
+    assert not vehicle.vehicle_state.speed_limit_mode.active
+    assert vehicle.vehicle_state.speed_limit_mode.current_limit_mph == 75.0
+    assert vehicle.vehicle_state.speed_limit_mode.max_limit_mph == 90
+    assert vehicle.vehicle_state.speed_limit_mode.min_limit_mph == 50
+    assert not vehicle.vehicle_state.speed_limit_mode.pin_code_set
+
+    assert vehicle.vehicle_config.can_accept_navigation_requests
+    assert vehicle.vehicle_config.can_actuate_trunks
+    assert vehicle.vehicle_config.car_special_type == "base"
+    assert vehicle.vehicle_config.car_type == "models2"
+    assert vehicle.vehicle_config.charge_port_type == "US"
+    assert not vehicle.vehicle_config.eu_vehicle
+    assert vehicle.vehicle_config.exterior_color == "White"
+    assert vehicle.vehicle_config.has_air_suspension
+    assert not vehicle.vehicle_config.has_ludicrous_mode
+    assert vehicle.vehicle_config.key_version == 1
+    assert vehicle.vehicle_config.motorized_charge_port
+    assert vehicle.vehicle_config.perf_config == "P2"
+    assert vehicle.vehicle_config.plg
+    assert vehicle.vehicle_config.rear_seat_heaters == 0
+    assert vehicle.vehicle_config.rear_seat_type == 0
+    assert not vehicle.vehicle_config.rhd
+    assert vehicle.vehicle_config.roof_color == "None"
+    assert vehicle.vehicle_config.seat_type == 2
+    assert vehicle.vehicle_config.spoiler_type == "None"
+    assert vehicle.vehicle_config.sun_roof_installed == 2
+    assert vehicle.vehicle_config.third_row_seats == "None"
+    assert vehicle.vehicle_config.timestamp == 1538364666096
+    assert vehicle.vehicle_config.trim_badging == "p90d"
+    assert not vehicle.vehicle_config.use_range_badging
+    assert vehicle.vehicle_config.wheel_type == "AeroTurbine19"

--- a/tests/library/test_vehicle.py
+++ b/tests/library/test_vehicle.py
@@ -1,0 +1,50 @@
+"""Test vehicle."""
+
+import pytest
+
+from teslajsonpy.library.controller import Controller
+from teslajsonpy.library.vehicle import Vehicle
+
+from tests.mock.api_mock import ApiMock
+
+
+def test_on_init():
+    """Test initialization."""
+
+    vehicle = Vehicle(None, None)
+
+    assert vehicle.model is not None
+    assert vehicle.model.id is None
+    assert vehicle.is_locked is None
+    assert vehicle.is_trunk_closed is None
+    assert vehicle.is_frunk_closed is None
+    assert vehicle.is_sentry_mode_available is None
+    assert vehicle.is_sentry_mode_enabled is None
+    assert vehicle.inside_temperature is None
+    assert vehicle.outside_temperature is None
+
+
+@pytest.mark.asyncio
+async def test_load_vehicle(monkeypatch):
+    """Test initialization."""
+
+    ApiMock(monkeypatch)
+
+    identifier = 12345678901234567
+
+    controller = Controller()
+    await controller.connect("elon@teslamotors.com", "edisonsux")
+    await controller.refresh_vehicles()
+    assert len(controller.vehicles) > 0
+
+    vehicle = Vehicle(controller, identifier)
+
+    assert vehicle.model is not None
+    assert vehicle.model.id == identifier
+    assert vehicle.is_locked
+    assert vehicle.is_trunk_closed
+    assert vehicle.is_frunk_closed
+    assert vehicle.is_sentry_mode_available
+    assert vehicle.is_sentry_mode_enabled
+    assert vehicle.inside_temperature == 18.5
+    assert vehicle.outside_temperature == 12.0

--- a/tests/mock/api_mock.py
+++ b/tests/mock/api_mock.py
@@ -1,0 +1,287 @@
+"""API mock."""
+
+from typing import Dict
+
+from teslajsonpy.library.api import Api
+
+
+# pylint: disable=too-few-public-methods
+class ApiMock:
+    """Mock for API wrapper."""
+
+    def __init__(self, monkeypatch) -> None:
+        """Initialize mock.
+
+        Args:
+            monkeypatch (pytest.Monkeypatch): Monkeypatch.
+        """
+        self._monkeypatch = monkeypatch
+
+        self._monkeypatch.setattr(Api, "get_oauth_token", self.get_oauth_token)
+        self._monkeypatch.setattr(Api, "get_vehicles", self.get_vehicles)
+        self._monkeypatch.setattr(Api, "get_vehicle", self.get_vehicle)
+        self._monkeypatch.setattr(Api, "get_vehicle_data", self.get_vehicle_data)
+
+    async def get_oauth_token(self, *args, **kwargs):
+        # pylint: disable=no-self-use, unused-argument
+        """ Mock API get_oauth_token method."""
+        return GET_OAUTH_TOKEN
+
+    async def get_vehicles(self, *args, **kwargs):
+        # pylint: disable=no-self-use, unused-argument
+        """ Mock API get_vehicles method."""
+        return GET_VEHICLES
+
+    async def get_vehicle(self, *args, **kwargs):
+        # pylint: disable=no-self-use, unused-argument
+        """ Mock API get_vehicle method."""
+        return GET_VEHICLE
+
+    async def get_vehicle_data(self, *args, **kwargs):
+        # pylint: disable=no-self-use, unused-argument
+        """ Mock API get_vehicle_data method."""
+        return GET_VEHICLE_DATA
+
+
+VEHICLE_INFO = {
+    "id": 12345678901234567,
+    "vehicle_id": 1234567890,
+    "vin": "5YJSA11111111111",
+    "display_name": "Nikola 2.0",
+    "option_codes": "MDLS,RENA,AF02,APF1,APH2,APPB,AU01,BC0R,BP00,BR00,BS00,CDM0,CH05,PBCW,CW00,DCF0,DRLH,DSH7,DV4W,FG02,FR04,HP00,IDBA,IX01,LP01,ME02,MI01,PF01,PI01,PK00,PS01,PX00,PX4D,QTVB,RFP2,SC01,SP00,SR01,SU01,TM00,TP03,TR00,UTAB,WTAS,X001,X003,X007,X011,X013,X021,X024,X027,X028,X031,X037,X040,X044,YFFC,COUS",
+    "color": None,
+    "tokens": ["abcdef1234567890", "1234567890abcdef"],
+    "state": "online",
+    "in_service": False,
+    "id_s": "12345678901234567",
+    "calendar_enabled": True,
+    "api_version": 7,
+    "backseat_token": None,
+    "backseat_token_updated_at": None,
+}
+
+DRIVE_STATE = {
+    "gps_as_of": 1538363883,
+    "heading": 5,
+    "latitude": 33.111111,
+    "longitude": -88.111111,
+    "native_latitude": 33.111111,
+    "native_location_supported": 1,
+    "native_longitude": -88.111111,
+    "native_type": "wgs",
+    "power": 0,
+    "shift_state": None,
+    "speed": None,
+    "timestamp": 1538364666096,
+}
+
+CLIMATE_STATE = {
+    "battery_heater": False,
+    "battery_heater_no_power": False,
+    "climate_keeper_mode": "dog",
+    "defrost_mode": 0,
+    "driver_temp_setting": 21.6,
+    "fan_status": 0,
+    "inside_temp": 18.5,
+    "is_auto_conditioning_on": None,
+    "is_climate_on": False,
+    "is_front_defroster_on": False,
+    "is_preconditioning": False,
+    "is_rear_defroster_on": False,
+    "left_temp_direction": None,
+    "max_avail_temp": 28.0,
+    "min_avail_temp": 15.0,
+    "outside_temp": 12.0,
+    "passenger_temp_setting": 21.6,
+    "remote_heater_control_enabled": True,
+    "right_temp_direction": None,
+    "seat_heater_left": 3,
+    "seat_heater_rear_center": 0,
+    "seat_heater_rear_left": 1,
+    "seat_heater_rear_left_back": 0,
+    "seat_heater_rear_right": 1,
+    "seat_heater_rear_right_back": 0,
+    "seat_heater_right": 2,
+    "side_mirror_heaters": False,
+    "steering_wheel_heater": False,
+    "timestamp": 1543186971731,
+    "wiper_blade_heater": False,
+}
+
+CHARGE_STATE = {
+    "battery_heater_on": False,
+    "battery_level": 64,
+    "battery_range": 167.96,
+    "charge_current_request": 48,
+    "charge_current_request_max": 48,
+    "charge_enable_request": True,
+    "charge_energy_added": 12.41,
+    "charge_limit_soc": 90,
+    "charge_limit_soc_max": 100,
+    "charge_limit_soc_min": 50,
+    "charge_limit_soc_std": 90,
+    "charge_miles_added_ideal": 50.0,
+    "charge_miles_added_rated": 40.0,
+    "charge_port_cold_weather_mode": False,
+    "charge_port_door_open": False,
+    "charge_port_latch": "Engaged",
+    "charge_rate": 0.0,
+    "charge_to_max_range": False,
+    "charger_actual_current": 0,
+    "charger_phases": None,
+    "charger_pilot_current": 48,
+    "charger_power": 0,
+    "charger_voltage": 0,
+    "charging_state": "Disconnected",
+    "conn_charge_cable": "<invalid>",
+    "est_battery_range": 118.38,
+    "fast_charger_brand": "<invalid>",
+    "fast_charger_present": False,
+    "fast_charger_type": "<invalid>",
+    "ideal_battery_range": 209.95,
+    "managed_charging_active": False,
+    "managed_charging_start_time": None,
+    "managed_charging_user_canceled": False,
+    "max_range_charge_counter": 0,
+    "minutes_to_full_charge": 0,
+    "not_enough_power_to_heat": False,
+    "scheduled_charging_pending": False,
+    "scheduled_charging_start_time": None,
+    "time_to_full_charge": 0.0,
+    "timestamp": 1543186971727,
+    "trip_charging": False,
+    "usable_battery_level": 64,
+    "user_charge_enable_request": None,
+}
+
+GUI_SETTINGS = {
+    "gui_24_hour_time": False,
+    "gui_charge_rate_units": "mi/hr",
+    "gui_distance_units": "mi/hr",
+    "gui_range_display": "Rated",
+    "gui_temperature_units": "F",
+    "show_range_units": True,
+    "timestamp": 1543186971728,
+}
+
+VEHICLE_STATE = {
+    "api_version": 7,
+    "autopark_state_v3": "standby",
+    "autopark_style": "standard",
+    "calendar_supported": True,
+    "car_version": "2019.40.2.1 38f55d9f9205",
+    "center_display_state": 0,
+    "df": 0,
+    "dr": 0,
+    "fd_window": 0,
+    "fp_window": 0,
+    "ft": 0,
+    "homelink_device_count": 0,
+    "homelink_nearby": True,
+    "is_user_present": False,
+    "last_autopark_error": "no_error",
+    "locked": True,
+    "media_state": {"remote_control_enabled": True},
+    "notifications_supported": True,
+    "odometer": 33561.422505,
+    "parsed_calendar_supported": True,
+    "pf": 0,
+    "pr": 0,
+    "rd_window": 0,
+    "remote_start": False,
+    "remote_start_enabled": True,
+    "remote_start_supported": True,
+    "rp_window": 0,
+    "rt": 0,
+    "sentry_mode": True,
+    "sentry_mode_available": True,
+    "smart_summon_available": True,
+    "software_update": {
+        "download_perc": 100,
+        "expected_duration_sec": 2700,
+        "install_perc": 10,
+        "scheduled_time_ms": 1575689678432,
+        "status": "scheduled",
+        "version": "2019.40.2.1",
+    },
+    "speed_limit_mode": {
+        "active": False,
+        "current_limit_mph": 75.0,
+        "max_limit_mph": 90,
+        "min_limit_mph": 50,
+        "pin_code_set": False,
+    },
+    "summon_standby_mode_enabled": True,
+    "sun_roof_percent_open": 0,
+    "sun_roof_state": "unknown",
+    "timestamp": 1538364666096,
+    "valet_mode": False,
+    "valet_pin_needed": True,
+    "vehicle_name": "Nikola 2.0",
+}
+
+VEHICLE_CONFIG = {
+    "can_accept_navigation_requests": True,
+    "can_actuate_trunks": True,
+    "car_special_type": "base",
+    "car_type": "models2",
+    "charge_port_type": "US",
+    "eu_vehicle": False,
+    "exterior_color": "White",
+    "has_air_suspension": True,
+    "has_ludicrous_mode": False,
+    "key_version": 1,
+    "motorized_charge_port": True,
+    "perf_config": "P2",
+    "plg": True,
+    "rear_seat_heaters": 0,
+    "rear_seat_type": 0,
+    "rhd": False,
+    "roof_color": "None",
+    "seat_type": 2,
+    "spoiler_type": "None",
+    "sun_roof_installed": 2,
+    "third_row_seats": "None",
+    "timestamp": 1538364666096,
+    "trim_badging": "p90d",
+    "use_range_badging": False,
+    "wheel_type": "AeroTurbine19",
+}
+
+VEHICLE_DATA = {
+    "id": 12345678901234567,
+    "user_id": 123,
+    "vehicle_id": 1234567890,
+    "vin": "5YJSA11111111111",
+    "display_name": "Nikola 2.0",
+    "option_codes": "MDLS,RENA,AF02,APF1,APH2,APPB,AU01,BC0R,BP00,BR00,BS00,CDM0,CH05,PBCW,CW00,DCF0,DRLH,DSH7,DV4W,FG02,FR04,HP00,IDBA,IX01,LP01,ME02,MI01,PF01,PI01,PK00,PS01,PX00,PX4D,QTVB,RFP2,SC01,SP00,SR01,SU01,TM00,TP03,TR00,UTAB,WTAS,X001,X003,X007,X011,X013,X021,X024,X027,X028,X031,X037,X040,X044,YFFC,COUS",
+    "color": None,
+    "tokens": ["abcdef1234567890", "1234567890abcdef"],
+    "state": "online",
+    "in_service": False,
+    "id_s": "12345678901234567",
+    "calendar_enabled": True,
+    "api_version": 7,
+    "backseat_token": None,
+    "backseat_token_updated_at": None,
+    "drive_state": DRIVE_STATE,
+    "climate_state": CLIMATE_STATE,
+    "charge_state": CHARGE_STATE,
+    "gui_settings": GUI_SETTINGS,
+    "vehicle_state": VEHICLE_STATE,
+    "vehicle_config": VEHICLE_CONFIG,
+}
+
+GET_OAUTH_TOKEN = {
+    "access_token": "abc123",
+    "token_type": "bearer",
+    "expires_in": 3888000,
+    "refresh_token": "cba321",
+    "created_at": 1538359034,
+}
+
+GET_VEHICLES = {"response": [VEHICLE_INFO]}
+
+GET_VEHICLE = {"response": VEHICLE_INFO}
+
+GET_VEHICLE_DATA = {"response": VEHICLE_DATA}

--- a/tests/mock/connection_mock.py
+++ b/tests/mock/connection_mock.py
@@ -1,0 +1,22 @@
+"""Connection mock."""
+
+from teslajsonpy.library.connection import Connection
+
+
+# pylint: disable=too-few-public-methods
+class ConnectionMock:
+    """Mock for HTTP connection."""
+
+    def __init__(self, monkeypatch) -> None:
+        """Initialize mock.
+
+        Args:
+            monkeypatch (pytest.Monkeypatch): Monkeypatch.
+        """
+        self._monkeypatch = monkeypatch
+        self._monkeypatch.setattr(Connection, "request", self.mock_request)
+
+    async def mock_request(self, *args, **kwargs):
+        # pylint: disable=no-self-use, unused-argument
+        """ Mock Connection's request method."""
+        return {}


### PR DESCRIPTION
Following issue #24, this PR provides an idea for re-architecturing the library vs. HA implementation.

Concept:

- Provide HA abstract base objects: entity, binary sensor, switch, etc.
- Provide Tesla entities as implementation of base object, eg. ParkingSensor(BinarySensor)
- Tesla entity calls library controller for state updates and commands
- Home Assistant integration uses Tesla objects

