### PR TITLE
Add charge limit soc

### DIFF
--- a/teslajsonpy/homeassistant/battery_sensor.py
+++ b/teslajsonpy/homeassistant/battery_sensor.py
@@ -26,6 +26,7 @@ class Battery(VehicleDevice):
         self.__battery_level: int = None
         self.__charging_state: bool = None
         self.__charge_port_door_open: bool = None
+        self.__charge_limit_soc = int = None
         self.type: Text = "battery sensor"
         self.measurement: Text = "%"
         self.hass_type: Text = "sensor"
@@ -49,6 +50,7 @@ class Battery(VehicleDevice):
         if data:
             self.__battery_level = data["battery_level"]
             self.__charging_state = data["charging_state"] == "Charging"
+            self.__charge_limit_soc = data["charge_limit_soc"]
 
     @staticmethod
     def has_battery() -> bool:


### PR DESCRIPTION
The goal for this PR is to make charger_soc limit at a attribute in the ``sensor.tesla_model_3_battery_sensor``, I'm not sure if this is al that is required or if additial changes is needed. I got lost in all the abstractions of the api.

Closes #114 