### PR TITLE
Don't use dummy module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ LICENSE = "Apache-2.0"
 VERSION = None
 
 # What packages are required for this module to be executed?
-REQUIRED = ["aiohttp", "backoff", "bs4", "wrapt"]
+REQUIRED = ["aiohttp", "backoff", "beautifulsoup4", "wrapt"]
 
 # What packages are optional?
 EXTRAS = {


### PR DESCRIPTION
`bs4` is a only dummy module for `beautifulsoup4`.

