### PR TITLE
fix: increase delay for refresh and update message

### DIFF
--- a/teslajsonpy/teslaproxy.py
+++ b/teslajsonpy/teslaproxy.py
@@ -82,13 +82,13 @@ class TeslaProxy(AuthCaptureProxy):
         if resp.content_type == "text/html":
             text = await resp.text()
             if "<noscript>Please enable JavaScript to view the page content." in text:
-                _LOGGER.debug("WAF discovered.")
+                _LOGGER.debug("WAF discovered %s times in a row.", self.waf_retry)
                 self.waf_retry += 1
                 return return_timer_countdown_refresh_html(
                     max(30 * (self.waf_retry - self.waf_limit), 120)
                     if self.waf_retry > self.waf_limit
-                    else random.random() * self.waf_retry,
-                    "Detected Tesla web application firewall block. Please wait and then reload the page or wait for the auto reload.",
+                    else random.random() * self.waf_retry + 10,
+                    f"Detected Tesla web application firewall block #{self.waf_retry}. Please wait and then reload the page or wait for the auto reload.",
                 )
             self.waf_retry = 0
         if resp.content_type == "application/json":


### PR DESCRIPTION
With a delay below 10 seconds, it would be a login could be interrupted
by the refresh. Increased to a minimum of 10 seconds.