### PR TITLE
Check response before json

### DIFF
--- a/teslajsonpy/connection.py
+++ b/teslajsonpy/connection.py
@@ -202,8 +202,7 @@ class Connection:
                 resp = await getattr(self.websession, method)(
                     str(url), headers=headers, cookies=cookies
                 )
-            data = resp.json()
-            _LOGGER.debug("%s: %s", resp.status_code, json.dumps(data))
+            _LOGGER.debug("%s: %s", resp.status_code, resp.text)
             if resp.status_code > 299:
                 if resp.status_code == 401:
                     if data and data.get("error") == "invalid_token":
@@ -211,6 +210,7 @@ class Connection:
                 elif resp.status_code == 408:
                     raise TeslaException(resp.status_code, "vehicle_unavailable")
                 raise TeslaException(resp.status_code)
+            data = resp.json()
             if data.get("error"):
                 # known errors:
                 #     'vehicle unavailable: {:error=>"vehicle unavailable:"}',


### PR DESCRIPTION
Fixes

```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 264, in async_setup
    result = await component.async_setup_entry(hass, self)  # type: ignore
  File "/usr/src/homeassistant/homeassistant/components/tesla/__init__.py", line 163, in async_setup_entry
    result = await controller.connect(
  File "/usr/local/lib/python3.8/site-packages/teslajsonpy/controller.py", line 288, in connect
    cars = await self.get_vehicles()
  File "/usr/local/lib/python3.8/site-packages/backoff/_async.py", line 133, in retry
    ret = await target(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/teslajsonpy/controller.py", line 407, in get_vehicles
    return (await self.__connection.get("vehicles"))["response"]
  File "/usr/local/lib/python3.8/site-packages/teslajsonpy/connection.py", line 90, in get
    return await self.post(command, "get", None)
  File "/usr/local/lib/python3.8/site-packages/teslajsonpy/connection.py", line 161, in post
    return await self.__open(
  File "/usr/local/lib/python3.8/site-packages/teslajsonpy/connection.py", line 205, in __open
    data = resp.json()
  File "/usr/local/lib/python3.8/site-packages/httpx/_models.py", line 1416, in json
    return jsonlib.loads(self.text, **kwargs)
  File "/usr/local/lib/python3.8/json/__init__.py", line 357, in loads
    return _default_decoder.decode(s)
  File "/usr/local/lib/python3.8/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/lib/python3.8/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```