### PR TITLE
Fix bug in refresh_access_token

### DIFF
--- a/teslajsonpy/connection.py
+++ b/teslajsonpy/connection.py
@@ -553,7 +553,7 @@ class Connection:
             "scope": "openid email offline_access",
         }
         auth = await self.websession.post(
-            self.auth_domain.with_path("/oauth2/v3/token"),
+            str(self.auth_domain.with_path("/oauth2/v3/token")),
             data=oauth,
         )
         return auth.json()


### PR DESCRIPTION
Throws an exception when calling refresh_access_token that the URL parameter is nether a string nor a httpx.Url