### PR TITLE
fix: allow auth using refresh_token

### DIFF
--- a/teslajsonpy/connection.py
+++ b/teslajsonpy/connection.py
@@ -122,6 +122,10 @@ class Connection:
                 auth = await self.refresh_access_token(
                     refresh_token=self.sso_oauth.get("refresh_token")
                 )
+            elif self.refresh_token:
+                auth = await self.refresh_access_token(
+                    refresh_token=self.refresh_token
+                )
             if auth and all(
                 (
                     auth.get(item)


### PR DESCRIPTION
This fix will allow a user to provide a refresh token generated by apps like "AuthAppForTesla" etc to authenticate. This is the way Telsamate, Teslascope and others are authenticating and it works.

This will require that the core Tesla integration in Home Assistant is updated to be able to provide the refresh_token, but this change is a prerequisite.

Related issue #205.