### PR TITLE
feat: add id_token to connect() response and return correct refresh_t…

### DIFF
--- a/teslajsonpy/connection.py
+++ b/teslajsonpy/connection.py
@@ -63,6 +63,7 @@ class Connection:
         self.api: Text = "/api/1/"
         self.expiration: int = expiration
         self.access_token = access_token
+        self.id_token = None
         self.head = None
         self.refresh_token = refresh_token
         self.websession = websession
@@ -123,9 +124,7 @@ class Connection:
                     refresh_token=self.sso_oauth.get("refresh_token")
                 )
             elif self.refresh_token:
-                auth = await self.refresh_access_token(
-                    refresh_token=self.refresh_token
-                )
+                auth = await self.refresh_access_token(refresh_token=self.refresh_token)
             if auth and all(
                 (
                     auth.get(item)
@@ -137,6 +136,8 @@ class Connection:
                     "refresh_token": auth["refresh_token"],
                     "expires_in": auth["expires_in"] + now,
                 }
+                self.id_token = auth["id_token"]
+                self.refresh_token = auth["refresh_token"]
                 _LOGGER.debug("Saved new auth info %s", self.sso_oauth)
             else:
                 _LOGGER.debug("Unable to refresh sso oauth token")
@@ -159,7 +160,6 @@ class Connection:
                 self.__sethead(
                     access_token=auth["access_token"], expires_in=auth["expires_in"]
                 )
-            self.refresh_token = auth["refresh_token"]
             self.token_refreshed = True
             _LOGGER.debug("Successfully refreshed oauth")
         return await self.__open(

--- a/teslajsonpy/controller.py
+++ b/teslajsonpy/controller.py
@@ -285,7 +285,7 @@ class Controller:
             mfa_code (Text, optional): MFA code to use for connection
 
         Returns
-            Dict[Text, Text]: Returns the refresh_token, access_token, and expires_in time
+            Dict[Text, Text]: Returns the refresh_token, access_token, id_token and expires_in time
 
         """
 
@@ -336,6 +336,7 @@ class Controller:
             "refresh_token": self.__connection.refresh_token,
             "access_token": self.__connection.access_token,
             "expiration": self.__connection.expiration,
+            "id_token": self.__connection.id_token,
         }
 
     async def disconnect(self) -> None:
@@ -358,7 +359,7 @@ class Controller:
         This will set the the self.__connection token_refreshed to False.
 
         Returns
-            Dict[Text, Text]: Returns the refresh_token, access_token, and expires time
+            Dict[Text, Text]: Returns the refresh_token, access_token, id_token and expires time
 
         """
         self.__connection.token_refreshed = False
@@ -366,6 +367,7 @@ class Controller:
             "refresh_token": self.__connection.refresh_token,
             "access_token": self.__connection.access_token,
             "expiration": self.__connection.expiration,
+            "id_token": self.__connection.id_token,
         }
 
     def get_expiration(self) -> int:


### PR DESCRIPTION
…oken (#217)

* Add id_token to connect() response

* Set refresh token to the one returned from auth-api and not owner api