### PR TITLE
Expose max charger variable

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,3 +15,4 @@
 -   hobbe [GitHub](https://github.com/hobbe)
 -   megabytemb [GitHub](https://github.com/megabytemb)
 -   giachello [Github](https://github.com/giachello)
+-   danielp370 [Github](https://github.com/danielp370)

--- a/teslajsonpy/homeassistant/charger.py
+++ b/teslajsonpy/homeassistant/charger.py
@@ -176,6 +176,7 @@ class ChargingSensor(VehicleDevice):
         self.__charging_rate = None
         self.__time_to_full = None
         self.__charge_current_request = None
+        self.__charge_current_request_max = None
         self.__charger_actual_current = None
         self.__charger_voltage = None
         self.__charge_limit_soc = None
@@ -208,6 +209,7 @@ class ChargingSensor(VehicleDevice):
             self.__charging_rate = data["charge_rate"]
             self.__time_to_full = data["time_to_full_charge"]
             self.__charge_current_request = data["charge_current_request"]
+            self.__charge_current_request_max = data["charge_current_request_max"]
             self.__charger_actual_current = data["charger_actual_current"]
             self.__charger_voltage = data["charger_voltage"]
             self.__charge_limit_soc = data["charge_limit_soc"]
@@ -241,6 +243,11 @@ class ChargingSensor(VehicleDevice):
     def charge_current_request(self) -> float:
         """Return the requested current."""
         return self.__charge_current_request
+
+    @property
+    def charge_current_request_max(self) -> float:
+        """Return the requested current max."""
+        return self.__charge_current_request_max
 
     @property
     def charger_actual_current(self) -> float:
@@ -304,6 +311,7 @@ class ChargingEnergySensor(VehicleDevice):
         self.__charging_rate = None
         self.__time_to_full = None
         self.__charge_current_request = None
+        self.__charge_current_request_max = None
         self.__charger_actual_current = None
         self.__charger_voltage = None
         self.__charge_limit_soc = None
@@ -342,6 +350,7 @@ class ChargingEnergySensor(VehicleDevice):
             self.__charging_rate = data["charge_rate"]
             self.__time_to_full = data["time_to_full_charge"]
             self.__charge_current_request = data["charge_current_request"]
+            self.__charge_current_request_max = data["charge_current_request_max"]
             self.__charger_actual_current = data["charger_actual_current"]
             self.__charger_voltage = data["charger_voltage"]
             self.__charge_limit_soc = data["charge_limit_soc"]
@@ -376,6 +385,11 @@ class ChargingEnergySensor(VehicleDevice):
     def charge_current_request(self) -> float:
         """Return the requested current."""
         return self.__charge_current_request
+
+    @property
+    def charge_current_request_max(self) -> float:
+        """Return the requested current max."""
+        return self.__charge_current_request_max
 
     @property
     def charger_actual_current(self) -> float:

--- a/tests/unit_tests/homeassistant/test_charging_sensor.py
+++ b/tests/unit_tests/homeassistant/test_charging_sensor.py
@@ -66,6 +66,7 @@ def test_get_value_on_init(monkeypatch):
         assert _sensor.time_left is None
         assert _sensor.added_range is None
         assert _sensor.charge_current_request is None
+        assert _sensor.charge_current_request_max is None
         assert _sensor.charger_actual_current is None
         assert _sensor.charger_voltage is None
         assert _sensor.charger_power is None
@@ -90,6 +91,7 @@ async def test_get_value_after_update(monkeypatch):
     assert _sensor.time_left == 0
     assert _sensor.added_range == 40
     assert _sensor.charge_current_request == 48
+    assert _sensor.charge_current_request_max == 48
     assert _sensor.charger_actual_current == 0
     assert _sensor.charger_voltage == 0
     assert _sensor.charger_power == 0
@@ -104,6 +106,7 @@ async def test_get_value_after_update(monkeypatch):
     assert _sensor2.charging_rate == 0
     assert _sensor2.time_left == 0
     assert _sensor2.charge_current_request == 48
+    assert _sensor2.charge_current_request_max == 48
     assert _sensor2.charger_actual_current == 0
     assert _sensor2.charger_voltage == 0
     assert _sensor2.charger_power == 0
@@ -130,6 +133,7 @@ async def test_async_update(monkeypatch):
     assert _sensor.time_left == 0
     assert _sensor.added_range == 40
     assert _sensor.charge_current_request == 48
+    assert _sensor.charge_current_request_max == 48
     assert _sensor.charger_actual_current == 0
     assert _sensor.charger_voltage == 0
     assert _sensor.charge_energy_added == 12.41


### PR DESCRIPTION
Here is a PR to expose Charger's charge_current_request_max variable.  

I have a use case where I have multiple chargers (and cars) with different maximum charge capabilities. It would be really helpful to have max exposed so that I know up-front how much current I can push to each one by querying this variable.

Thanks