### PR TITLE
fix(energysites): changing unknown grid status logic

### DIFF
--- a/teslajsonpy/homeassistant/power.py
+++ b/teslajsonpy/homeassistant/power.py
@@ -134,9 +134,8 @@ class PowerSensor(EnergySiteDevice):
         super().refresh()
         data = self._controller.get_power_params(self._id)
         if data:
-            if "grid_status" in data and data["grid_status"] == "Unknown":
-                return
-
+            # Note: Some systems that pre-date Tesla aquisition of SolarCity will have `grid_status: Unknown`,
+            # but will have solar power values
             self.__power = data["solar_power"]
             if data["solar_power"] is not None:
                 self.__generating_status = (

--- a/tests/tesla_mock.py
+++ b/tests/tesla_mock.py
@@ -55,6 +55,7 @@ class TeslaMock:
         self._vehicle_config = copy.deepcopy(VEHICLE_CONFIG)
         self._energysite_config = copy.deepcopy(ENERGYSITE_CONFIG)
         self._energysite_state = copy.deepcopy(ENERGYSITE_STATE)
+        self._energysite_state_unknown_grid = copy.deepcopy(ENERGYSITE_STATE_UNKNOWN_GRID)
         self._energysite_config_no_name = copy.deepcopy(ENERGYSITE_CONFIG_NO_NAME)
 
         self._vehicle = copy.deepcopy(VEHICLE)
@@ -94,6 +95,11 @@ class TeslaMock:
         # pylint: disable=unused-argument
         """ Mock controller's get_climate_params method."""
         return self.controller_get_power_params()
+
+    def mock_get_power_unknown_grid_params(self, *args, **kwargs):
+        # pylint: disable=unused-argument
+        """ Mock controller's get_climate_params method."""
+        return self.controller_get_power_unknown_grid_params()
 
     def mock_get_drive_params(self, *args, **kwargs):
         # pylint: disable=unused-argument
@@ -152,6 +158,10 @@ class TeslaMock:
         """ Monkeypatch for controller.get_climate_params()."""
         return self._energysite_state
 
+    def controller_get_power_unknown_grid_params(self):
+        """ Monkeypatch for controller.get_climate_params()."""
+        return self._energysite_state_unknown_grid
+
     def controller_get_drive_params(self):
         """ Monkeypatch for controller.get_drive_params()."""
         return self._drive_state
@@ -203,6 +213,13 @@ class TeslaMock:
         """ Similates the result of energy site data request without a name"""
         return self._energysite_config_no_name
 
+    def data_request_energy_state(self):
+        """ Similates the result of energy status data request"""
+        return self._energysite_state
+
+    def data_request_energy_state_unknown_grid(self):
+        """ Similates the result of energy status unknown grid data request"""
+        return self._energysite_state_unknown_grid
 
     @staticmethod
     def command_ok():
@@ -475,5 +492,13 @@ ENERGYSITE_CONFIG_NO_NAME = {
 ENERGYSITE_STATE = {
     "id": 12345678901234567,
     "timestamp": "2011-01-01",
-    "solar_power": 1800,
+    "solar_power": 1900,
+}
+
+ENERGYSITE_STATE_UNKNOWN_GRID = {
+    "id": 12345678901234567,
+    "timestamp": "2011-01-01",
+    "solar_power": 1750,
+    "grid_status": "Unknown",
+    "grid_services_active": False,
 }

--- a/tests/unit_tests/homeassistant/test_power_sensor.py
+++ b/tests/unit_tests/homeassistant/test_power_sensor.py
@@ -59,4 +59,24 @@ async def test_get_power_after_update(monkeypatch):
 
     assert _sensor is not None
     assert not _sensor.get_power() is None
-    assert _sensor.get_power() == 1800
+    assert _sensor.get_power() == 1900
+
+@pytest.mark.asyncio
+async def test_get_power_after_update_with_unknown_status(monkeypatch):
+    """Test get_power()  after an update with an unknown grid status."""
+
+    _mock = TeslaMock(monkeypatch)
+    monkeypatch.setattr(
+        Controller, "get_power_params", _mock.mock_get_power_unknown_grid_params
+    )
+    _controller = Controller(None)
+
+    _data = _mock.data_request_energy_site()
+    _data["solar_power"] = 1800
+    _sensor = PowerSensor(_data, _controller)
+
+    await _sensor.async_update()
+
+    assert _sensor is not None
+    assert not _sensor.get_power() is None
+    assert _sensor.get_power() == 1750


### PR DESCRIPTION
I have a solar city system from 2007 that is now in Tesla's system. It has the following response for the `live_status` endpoint:

```json
{
    "response": {
        "solar_power": 1760,
        "grid_status": "Unknown",
        "grid_services_active": false,
        "timestamp": "2021-12-24T13:09:39-08:00"
    }
}
```

Because of the `grid_status` its value was not updating in homeassistant.