### PR TITLE
Fix timestamp comparisons

### DIFF
--- a/teslajsonpy/controller.py
+++ b/teslajsonpy/controller.py
@@ -893,7 +893,7 @@ class Controller:
                             or vin not in self._last_update_time
                             or (
                                 (cur_time - self._last_update_time[vin])
-                                > _calculate_next_interval(vin)
+                                >= _calculate_next_interval(vin)
                             )
                         )
                     ):  # Only update cars with update flag on


### PR DESCRIPTION
Update will skip every other run, if the previous update took less than a second to complete.
Comparing with ">=" fixes this.