### PR TITLE
Provide all data in home assistant sensor as json string

### DIFF
--- a/teslajsonpy/homeassistant/binary_sensor.py
+++ b/teslajsonpy/homeassistant/binary_sensor.py
@@ -5,6 +5,7 @@ Python Package for controlling Tesla API.
 For more details about this api, please refer to the documentation at
 https://github.com/zabuldon/teslajsonpy
 """
+from json import dumps
 from typing import Dict, Optional, Text
 
 from teslajsonpy.const import RELEASE_NOTES_URL
@@ -214,6 +215,15 @@ class OnlineSensor(BinarySensor):
         self.attrs["vin"] = self.vin()
         self.attrs["id"] = self.id()
         self.attrs["update_interval"] = self._controller.update_interval
+        vehicle_data = {
+            "climate_state": self._controller.get_climate_params(self._id),
+            "charge_state": self._controller.get_charging_params(self._id), 
+            "vehicle_state":  self._controller.get_state_params(self._id),
+            "vehicle_config": self._controller.get_config_params(self._id),
+            "drive_state": self._controller.get_drive_params(self._id),
+            "gui_settings": self._controller.get_gui_params(self._id)            
+        }
+        self.attrs["vehicle_data"] = dumps(vehicle_data)
 
     def get_value(self) -> Optional[bool]:
         """Return the car is online."""

--- a/teslajsonpy/homeassistant/binary_sensor.py
+++ b/teslajsonpy/homeassistant/binary_sensor.py
@@ -217,11 +217,11 @@ class OnlineSensor(BinarySensor):
         self.attrs["update_interval"] = self._controller.update_interval
         vehicle_data = {
             "climate_state": self._controller.get_climate_params(self._id),
-            "charge_state": self._controller.get_charging_params(self._id), 
-            "vehicle_state":  self._controller.get_state_params(self._id),
+            "charge_state": self._controller.get_charging_params(self._id),
+            "vehicle_state": self._controller.get_state_params(self._id),
             "vehicle_config": self._controller.get_config_params(self._id),
             "drive_state": self._controller.get_drive_params(self._id),
-            "gui_settings": self._controller.get_gui_params(self._id)            
+            "gui_settings": self._controller.get_gui_params(self._id)
         }
         self.attrs["vehicle_data"] = dumps(vehicle_data)
 

--- a/tests/unit_tests/homeassistant/test_online_sensor.py
+++ b/tests/unit_tests/homeassistant/test_online_sensor.py
@@ -5,9 +5,9 @@ import pytest
 from teslajsonpy.controller import Controller
 from teslajsonpy.homeassistant.binary_sensor import OnlineSensor
 
-from tests.tesla_mock import TeslaMock
+from tests.tesla_mock import TeslaMock, VIN
 
-VIN = "5YJSA11111111111"
+# VIN = "5YJSA11111111111"
 
 
 def test_has_battery(monkeypatch):
@@ -78,14 +78,9 @@ async def test_get_value_on(monkeypatch):
         "id": 12345678901234567,
         "vehicle_id": 1234567890,
         "update_interval": 300,
-        "vehicle_data": {
-            "climate_state": {},
-            "charge_state": {},
-            "vehicle_state": {},
-            "vehicle_config": {},
-            "drive_state": {},
-            "gui_settings": {},
-        }
+        'vehicle_data': '{"climate_state": {}, "charge_state": {}, "vehicle_state": '
+                        '{}, "vehicle_config": {}, "drive_state": {}, "gui_settings": '
+                        '{}}'
     }
 
 

--- a/tests/unit_tests/homeassistant/test_online_sensor.py
+++ b/tests/unit_tests/homeassistant/test_online_sensor.py
@@ -149,5 +149,5 @@ async def test_get_vehicle_data_attribute(monkeypatch):
                                             ' "vehicle_state": {"rt": 0},'\
                                             ' "vehicle_config": {"car_type": "model3"},'\
                                             ' "drive_state": {"shift_state": "P"},'\
-                                            ' "gui_settings": {"gui_range_display": "Rated"}'
+                                            ' "gui_settings": {"gui_range_display": "Rated"}}'
     

--- a/tests/unit_tests/homeassistant/test_online_sensor.py
+++ b/tests/unit_tests/homeassistant/test_online_sensor.py
@@ -113,12 +113,7 @@ async def test_get_value_off(monkeypatch):
         "id": 12345678901234567,
         "vehicle_id": 1234567890,
         "update_interval": 300,
-        "vehicle_data": {
-            "climate_state": {},
-            "charge_state": {},
-            "vehicle_state": {},
-            "vehicle_config": {},
-            "drive_state": {},
-            "gui_settings": {},
-        }
-    }
+        "vehicle_data": '{"climate_state": {}, "charge_state": {}, "vehicle_state": '
+                        '{}, "vehicle_config": {}, "drive_state": {}, "gui_settings": '
+                        '{}}'
+                        

--- a/tests/unit_tests/homeassistant/test_online_sensor.py
+++ b/tests/unit_tests/homeassistant/test_online_sensor.py
@@ -101,7 +101,13 @@ async def test_get_value_off(monkeypatch):
     _data = _mock.data_request_vehicle()
     _sensor = OnlineSensor(_data, _controller)
     _data["state"] = "asleep"
-
+    _controller.set_climate_params(vin=VIN, params={'climate_state': 'on'})
+    _controller.set_charging_params(vin=VIN, params={'charging_state': 'on'})
+    _controller.set_state_params(vin=VIN, params={'vehicle_state': 'on'})
+    _controller.set_config_params(vin=VIN, params={'vehicle_config': 'on'})
+    _controller.set_drive_params(vin=VIN, params={'drive_state': 'on'})
+    _controller.set_gui_params(vin=VIN, params={'gui_setting': 'on'})
+    
     await _sensor.async_update()
 
     assert _sensor is not None
@@ -113,7 +119,10 @@ async def test_get_value_off(monkeypatch):
         "id": 12345678901234567,
         "vehicle_id": 1234567890,
         "update_interval": 300,
-        "vehicle_data": '{"climate_state": {}, "charge_state": {}, "vehicle_state": '
-                        '{}, "vehicle_config": {}, "drive_state": {}, "gui_settings": '
-                        '{}}'
-                        
+        "vehicle_data": '{"climate_state": {"climate_state": "on"},'
+                        ' "charge_state": {"charge_state": "on"},'
+                        ' "vehicle_state": {"vehicle_state": "on"},'
+                        ' "vehicle_config": {"vehicle_config": "on"},'
+                        ' "drive_state": {"drive_state": "on"},'
+                        ' "gui_settings": {"gui_settings": "on"}'
+    }

--- a/tests/unit_tests/homeassistant/test_online_sensor.py
+++ b/tests/unit_tests/homeassistant/test_online_sensor.py
@@ -78,6 +78,14 @@ async def test_get_value_on(monkeypatch):
         "id": 12345678901234567,
         "vehicle_id": 1234567890,
         "update_interval": 300,
+        "vehicle_data": {
+            "climate_state": {},
+            "charge_state": {},
+            "vehicle_state": {},
+            "vehicle_config": {},
+            "drive_state": {},
+            "gui_settings": {},
+        }
     }
 
 
@@ -105,4 +113,12 @@ async def test_get_value_off(monkeypatch):
         "id": 12345678901234567,
         "vehicle_id": 1234567890,
         "update_interval": 300,
+        "vehicle_data": {
+            "climate_state": {},
+            "charge_state": {},
+            "vehicle_state": {},
+            "vehicle_config": {},
+            "drive_state": {},
+            "gui_settings": {},
+        }
     }

--- a/tests/unit_tests/homeassistant/test_online_sensor.py
+++ b/tests/unit_tests/homeassistant/test_online_sensor.py
@@ -125,12 +125,12 @@ async def test_get_vehicle_data_attribute(monkeypatch):
 
     _data = _mock.data_request_vehicle()
     _sensor = OnlineSensor(_data, _controller)
-    _data["climate_state"]["inside_temp"] = 18.8
-    _data["charge_state"]["charge_rate"] = 22
-    _data["vehicle_state"]["rt"] = 0
-    _data["vehicle_config"]["car_type"] = "model3"
-    _data["drive_state"]["shift_state"] = "P"
-    _data["gui_settings"]["gui_range_display"] = "Rated"
+    _data["climate_state"] = {"inside_temp": 18.8}
+    _data["charge_state"] = {"charge_rate": 22}
+    _data["vehicle_state"] = {"rt": 0}
+    _data["vehicle_config"] = {"car_type": "model3"}
+    _data["drive_state"] = {"shift_state": "P"}
+    _data["gui_settings"] = {"gui_range_display": "Rated"}
 
     _controller.set_climate_params(vin=VIN, params=_data["climate_state"])
     _controller.set_charging_params(vin=VIN, params=_data["charge_state"])

--- a/tests/unit_tests/homeassistant/test_online_sensor.py
+++ b/tests/unit_tests/homeassistant/test_online_sensor.py
@@ -143,12 +143,11 @@ async def test_get_vehicle_data_attribute(monkeypatch):
     await _sensor.async_update()
 
     assert _sensor is not None
-    assert _sensor.attrs.vehicle_data is not None
-    assert _sensor.attrs.vehicle_data == {
-        "vehicle_data": '{"climate_state": {"inside_temp": 18.8},'
-                        ' "charge_state": {"charge_rate": 22},'
-                        ' "vehicle_state": {"rt": 0},'
-                        ' "vehicle_config": {"car_type": "model3"},'
-                        ' "drive_state": {"shift_state": "P"},'
-                        ' "gui_settings": {"gui_range_display": "Rated"}'
-    }
+    assert _sensor.attrs.get("vehicle_data") is not None
+    assert _sensor.attrs["vehicle_data"] == '{"climate_state": {"inside_temp": 18.8},'\
+                                            ' "charge_state": {"charge_rate": 22},'\
+                                            ' "vehicle_state": {"rt": 0},'\
+                                            ' "vehicle_config": {"car_type": "model3"},'\
+                                            ' "drive_state": {"shift_state": "P"},'\
+                                            ' "gui_settings": {"gui_range_display": "Rated"}'
+    


### PR DESCRIPTION
Not all data available through the API is exposed in the sensors to home assistant. Due to amount of available data it also won't make sense to expose everything as sensors or attributes.
This PR adds a new attribute (vehicle_data) to the binary OnlineSensor containing all the information retrieved from the API as a json string.
This then allows one to extract the data in templates and use as sensors.
For example, to get third row left seat heater in Model X:
```
{{ (state_attr('binary_sensor.<name>_online_sensor', 'vehicle_data') | from_json)['climate_state']['seat_heater_third_row_left'] }}
```

