### PR TITLE
Add per vehicle polling interval

### DIFF
--- a/teslajsonpy/const.py
+++ b/teslajsonpy/const.py
@@ -9,6 +9,7 @@ IDLE_INTERVAL = 600  # interval after parking to check at regular update_interva
 ONLINE_INTERVAL = 60  # interval for checking online state; does not hit individual cars
 SLEEP_INTERVAL = 660  # interval required to let vehicle sleep; based on testing
 DRIVING_INTERVAL = 60  # interval when driving detected
+UPDATE_INTERVAL = 300  # Default polling interval for vehicle
 WEBSOCKET_TIMEOUT = 11  # time for websocket to timeout
 RELEASE_NOTES_URL = "https://teslascope.com/teslapedia/software/"
 AUTH_DOMAIN = "https://auth.tesla.com"

--- a/teslajsonpy/controller.py
+++ b/teslajsonpy/controller.py
@@ -333,6 +333,7 @@ class Controller:
         )
         self.__components = []
         self._update_interval: int = update_interval
+        self._update_interval_vin = {}
         self.__update = {}
         self.__climate = {}
         self.__charging = {}
@@ -772,7 +773,7 @@ class Controller:
                 vin=vin, timestamp=cur_time, shift_state=self.shift_state(vin=vin)
             )
         if self.is_in_gear(vin=vin):
-            driving_interval = min(DRIVING_INTERVAL, self.update_interval)
+            driving_interval = min(DRIVING_INTERVAL, self.get_update_interval_vin(vin=vin))
             if self.__update_state[vin] != "driving":
                 self.__update_state[vin] = "driving"
                 _LOGGER.debug(
@@ -787,10 +788,10 @@ class Controller:
                 vin[-5:],
                 self.car_state[vin].get("state"),
                 self.polling_policy,
-                self.update_interval,
+                self.get_update_interval_vin(vin=vin),
             )
             self.__update_state[vin] = "normal"
-            return self.update_interval
+            return self.get_update_interval_vin(vin=vin)
         if self.polling_policy == "connected" and (
             self.is_sentry_mode_on(vin=vin)
             or self.is_climate_on(vin=vin)
@@ -808,16 +809,16 @@ class Controller:
                 vin[-5:],
                 self.car_state[vin].get("state"),
                 self.polling_policy,
-                self.update_interval,
+                self.get_update_interval_vin(vin=vin),
             )
             self.__update_state[vin] = "normal"
-            return self.update_interval
+            return self.get_update_interval_vin(vin=vin)
         if (cur_time - self.get_last_park_time(vin=vin) > IDLE_INTERVAL) and not (
             self.is_sentry_mode_on(vin=vin)
             or self.is_climate_on(vin=vin)
             or self.charging_state(vin=vin) == "Charging"
         ):
-            sleep_interval = max(SLEEP_INTERVAL, self.update_interval)
+            sleep_interval = max(SLEEP_INTERVAL, self.get_update_interval_vin(vin=vin))
             if self.__update_state[vin] != "trying_to_sleep":
                 self.__update_state[vin] = "trying_to_sleep"
             _LOGGER.debug(
@@ -836,9 +837,9 @@ class Controller:
                 vin[-5:],
                 self.car_state[vin].get("state"),
                 self.polling_policy,
-                self.update_interval,
+                self.get_update_interval_vin(vin=vin),
             )
-        return self.update_interval
+        return self.get_update_interval_vin(vin=vin)
 
     async def update(
         self,
@@ -1540,8 +1541,35 @@ class Controller:
     @update_interval.setter
     def update_interval(self, value: int) -> None:
         """Set update_interval."""
+        if value < 0:
+            value = 300
         if value:
+            _LOGGER.debug("Update interval set to %s.", value)
             self._update_interval = int(value)
+
+    def set_update_interval_vin(self, car_id: Text = None, vin: Text = None, value: int = None) -> None:
+        """Set update interval for specific vin."""
+
+        if car_id and not vin:
+            vin = self._id_to_vin(car_id)
+        if vin is None:
+            return
+        if value is None or value < 0:
+            _LOGGER.debug("%s: Update interval reset to default.", vin[-5:])
+            self._update_interval_vin.pop(vin, None)
+        else:
+            _LOGGER.debug("%s: Update interval set to %s.", vin[-5:], value)
+            self._update_interval_vin.update({vin:value})
+    
+    def get_update_interval_vin(self, car_id: Text = None, vin: Text = None) -> int:
+        """Get update interval for specific vin or default if no vin specific."""
+
+        if car_id and not vin:
+            vin = self._id_to_vin(car_id)
+        if vin is None or vin == "":
+            return self.update_interval
+
+        return self._update_interval_vin.get(vin, self.update_interval)
 
     def _id_to_vin(self, car_id: Text) -> Optional[Text]:
         """Return vin for a car_id."""

--- a/teslajsonpy/controller.py
+++ b/teslajsonpy/controller.py
@@ -26,6 +26,7 @@ from teslajsonpy.const import (
     DRIVING_INTERVAL,
     IDLE_INTERVAL,
     ONLINE_INTERVAL,
+    UPDATE_INTERVAL,
     SLEEP_INTERVAL,
     TESLA_PRODUCT_TYPE_ENERGY_SITES,
     TESLA_PRODUCT_TYPE_VEHICLES,
@@ -294,7 +295,7 @@ class Controller:
         access_token: Text = None,
         refresh_token: Text = None,
         expiration: int = 0,
-        update_interval: int = 300,
+        update_interval: int = UPDATE_INTERVAL,
         enable_websocket: bool = False,
         polling_policy: Text = None,
         auth_domain: str = AUTH_DOMAIN,
@@ -309,7 +310,7 @@ class Controller:
             refresh_token (Text, optional): Refresh token. Defaults to None.
             expiration (int, optional): Timestamp when access_token expires. Defaults to 0
             update_interval (int, optional): Seconds between allowed updates to the API.  This is to prevent
-            being blocked by Tesla. Defaults to 300.
+            being blocked by Tesla. Defaults to UPDATE_INTERVAL.
             enable_websocket (bool, optional): Whether to connect with websockets. Defaults to False.
             polling_policy (Text, optional): How aggressively will we poll the car. Possible values:
             Not set - Only keep the car awake while it is actively charging or driving, and while sentry
@@ -1542,7 +1543,7 @@ class Controller:
     def update_interval(self, value: int) -> None:
         """Set update_interval."""
         if value < 0:
-            value = 300
+            value = UPDATE_INTERVAL
         if value:
             _LOGGER.debug("Update interval set to %s.", value)
             self._update_interval = int(value)

--- a/teslajsonpy/controller.py
+++ b/teslajsonpy/controller.py
@@ -1559,8 +1559,8 @@ class Controller:
             self._update_interval_vin.pop(vin, None)
         else:
             _LOGGER.debug("%s: Update interval set to %s.", vin[-5:], value)
-            self._update_interval_vin.update({vin:value})
-    
+            self._update_interval_vin.update({vin: value})
+
     def get_update_interval_vin(self, car_id: Text = None, vin: Text = None) -> int:
         """Get update interval for specific vin or default if no vin specific."""
 

--- a/teslajsonpy/homeassistant/binary_sensor.py
+++ b/teslajsonpy/homeassistant/binary_sensor.py
@@ -214,7 +214,7 @@ class OnlineSensor(BinarySensor):
         self.attrs["vehicle_id"] = self.vehicle_id()
         self.attrs["vin"] = self.vin()
         self.attrs["id"] = self.id()
-        self.attrs["update_interval"] = self._controller.update_interval
+        self.attrs["update_interval"] = self._controller.get_update_interval_vin(vin=self._vin)
         vehicle_data = {
             "climate_state": self._controller.get_climate_params(self._id),
             "charge_state": self._controller.get_charging_params(self._id),

--- a/tests/unit_tests/test_polling_interval.py
+++ b/tests/unit_tests/test_polling_interval.py
@@ -6,6 +6,9 @@ from tests.tesla_mock import TeslaMock, VIN, CAR_ID
 DEFAULT_INTERVAL = 300
 VIN_INTERVAL = 5
 
+VIN2 = "5YJSA11111111112"
+CAR_ID2 = 86543210987654321
+
 
 def test_update_interval(monkeypatch):
     """Test update_interval property"""
@@ -33,20 +36,25 @@ def test_set_update_interval_vin(monkeypatch):
     monkeypatch.setitem(_controller.car_online, VIN, True)
     monkeypatch.setitem(_controller.car_state, VIN, _mock.data_request_vehicle())
     _controller.set_id_vin(CAR_ID, VIN)
+    _controller.set_id_vin(CAR_ID2, VIN2)
     _controller.update_interval = DEFAULT_INTERVAL
 
-    # Test setting interval for specific VIN.
+    # Test setting interval for VIN1.
     _controller.set_update_interval_vin(car_id=CAR_ID, value=VIN_INTERVAL)
     assert _controller._update_interval_vin[VIN] == VIN_INTERVAL
 
-    # Test setting interval for specific VIN back to default
+    # Test setting interval for  VIN2.
+    _controller.set_update_interval_vin(car_id=CAR_ID2, value=VIN_INTERVAL)
+    assert _controller._update_interval_vin[VIN2] == VIN_INTERVAL
+
+    # Test setting interval for VIN1 back to default
     _controller.set_update_interval_vin(car_id=CAR_ID)
     assert _controller._update_interval_vin.get(VIN) is None
+    assert _controller._update_interval_vin[VIN2] == VIN_INTERVAL
 
-    # Test setting interval for specific VIN back to default with negative
-    _controller.set_update_interval_vin(car_id=CAR_ID, value=VIN_INTERVAL)
-    _controller.set_update_interval_vin(car_id=CAR_ID, value=-1)
-    assert _controller._update_interval_vin.get(VIN) is None
+    # Test setting interval for VIN2 back to default with negative value
+    _controller.set_update_interval_vin(car_id=CAR_ID2, value=-1)
+    assert _controller._update_interval_vin.get(VIN2) is None
 
 
 def test_get_update_interval_vin(monkeypatch):
@@ -60,12 +68,13 @@ def test_get_update_interval_vin(monkeypatch):
     _controller.set_id_vin(CAR_ID, VIN)
     _controller.update_interval = DEFAULT_INTERVAL
 
-    # Test getting interval for specific VIN with it not set
+    # Test getting interval for VIN1 with it not set
     assert _controller.get_update_interval_vin(car_id=CAR_ID) == DEFAULT_INTERVAL
 
-    # Test getting interval for specific VIN with it set
+    # Test getting interval for VIN1 with it set and VIN2 not set
     _controller.set_update_interval_vin(car_id=CAR_ID, value=VIN_INTERVAL)
     assert _controller.get_update_interval_vin(car_id=CAR_ID) == VIN_INTERVAL
+    assert _controller.get_update_interval_vin(car_id=CAR_ID2) == DEFAULT_INTERVAL
 
     # Test getting interval when no VIN provided
     assert _controller.get_update_interval_vin() == DEFAULT_INTERVAL

--- a/tests/unit_tests/test_polling_interval.py
+++ b/tests/unit_tests/test_polling_interval.py
@@ -1,9 +1,9 @@
 """Test online sensor."""
 
 from teslajsonpy.controller import Controller
+from teslajsonpy.const import UPDATE_INTERVAL
 from tests.tesla_mock import TeslaMock, VIN, CAR_ID
 
-DEFAULT_INTERVAL = 300
 VIN_INTERVAL = 5
 
 VIN2 = "5YJSA11111111112"
@@ -19,7 +19,9 @@ def test_update_interval(monkeypatch):
     monkeypatch.setitem(_controller.car_online, VIN, True)
     monkeypatch.setitem(_controller.car_state, VIN, _mock.data_request_vehicle())
     _controller.set_id_vin(CAR_ID, VIN)
-    _controller._update_interval = DEFAULT_INTERVAL
+
+    # Test default update polling interval is set
+    assert _controller.update_interval == UPDATE_INTERVAL
 
     # Test default polling interval
     _controller.update_interval = VIN_INTERVAL
@@ -37,11 +39,11 @@ def test_set_update_interval_vin(monkeypatch):
     monkeypatch.setitem(_controller.car_state, VIN, _mock.data_request_vehicle())
     _controller.set_id_vin(CAR_ID, VIN)
     _controller.set_id_vin(CAR_ID2, VIN2)
-    _controller.update_interval = DEFAULT_INTERVAL
 
     # Test setting interval for VIN1.
     _controller.set_update_interval_vin(car_id=CAR_ID, value=VIN_INTERVAL)
     assert _controller._update_interval_vin[VIN] == VIN_INTERVAL
+    assert _controller.update_interval == UPDATE_INTERVAL
 
     # Test setting interval for  VIN2.
     _controller.set_update_interval_vin(car_id=CAR_ID2, value=VIN_INTERVAL)
@@ -66,15 +68,15 @@ def test_get_update_interval_vin(monkeypatch):
     monkeypatch.setitem(_controller.car_online, VIN, True)
     monkeypatch.setitem(_controller.car_state, VIN, _mock.data_request_vehicle())
     _controller.set_id_vin(CAR_ID, VIN)
-    _controller.update_interval = DEFAULT_INTERVAL
+    _controller.update_interval = UPDATE_INTERVAL
 
     # Test getting interval for VIN1 with it not set
-    assert _controller.get_update_interval_vin(car_id=CAR_ID) == DEFAULT_INTERVAL
+    assert _controller.get_update_interval_vin(car_id=CAR_ID) == UPDATE_INTERVAL
 
     # Test getting interval for VIN1 with it set and VIN2 not set
     _controller.set_update_interval_vin(car_id=CAR_ID, value=VIN_INTERVAL)
     assert _controller.get_update_interval_vin(car_id=CAR_ID) == VIN_INTERVAL
-    assert _controller.get_update_interval_vin(car_id=CAR_ID2) == DEFAULT_INTERVAL
+    assert _controller.get_update_interval_vin(car_id=CAR_ID2) == UPDATE_INTERVAL
 
     # Test getting interval when no VIN provided
-    assert _controller.get_update_interval_vin() == DEFAULT_INTERVAL
+    assert _controller.get_update_interval_vin() == UPDATE_INTERVAL

--- a/tests/unit_tests/test_polling_interval.py
+++ b/tests/unit_tests/test_polling_interval.py
@@ -1,0 +1,71 @@
+"""Test online sensor."""
+
+from teslajsonpy.controller import Controller
+from tests.tesla_mock import TeslaMock, VIN, CAR_ID
+
+DEFAULT_INTERVAL = 300
+VIN_INTERVAL = 5
+
+
+def test_update_interval(monkeypatch):
+    """Test update_interval property"""
+
+    _mock = TeslaMock(monkeypatch)
+    _controller = Controller(None)
+
+    monkeypatch.setitem(_controller.car_online, VIN, True)
+    monkeypatch.setitem(_controller.car_state, VIN, _mock.data_request_vehicle())
+    _controller.set_id_vin(CAR_ID, VIN)
+    _controller._update_interval = DEFAULT_INTERVAL
+
+    # Test default polling interval
+    _controller.update_interval = VIN_INTERVAL
+    assert _controller._update_interval == VIN_INTERVAL
+    assert _controller.update_interval == VIN_INTERVAL
+
+
+def test_set_update_interval_vin(monkeypatch):
+    """Test set_update_interval_vin()."""
+
+    _mock = TeslaMock(monkeypatch)
+    _controller = Controller(None)
+
+    monkeypatch.setitem(_controller.car_online, VIN, True)
+    monkeypatch.setitem(_controller.car_state, VIN, _mock.data_request_vehicle())
+    _controller.set_id_vin(CAR_ID, VIN)
+    _controller.update_interval = DEFAULT_INTERVAL
+
+    # Test setting interval for specific VIN.
+    _controller.set_update_interval_vin(car_id=CAR_ID, value=VIN_INTERVAL)
+    assert _controller._update_interval_vin[VIN] == VIN_INTERVAL
+
+    # Test setting interval for specific VIN back to default
+    _controller.set_update_interval_vin(car_id=CAR_ID)
+    assert _controller._update_interval_vin.get(VIN) is None
+
+    # Test setting interval for specific VIN back to default with negative
+    _controller.set_update_interval_vin(car_id=CAR_ID, value=VIN_INTERVAL)
+    _controller.set_update_interval_vin(car_id=CAR_ID, value=-1)
+    assert _controller._update_interval_vin.get(VIN) is None
+
+
+def test_get_update_interval_vin(monkeypatch):
+    """Test get_update_interval_vin()."""
+
+    _mock = TeslaMock(monkeypatch)
+    _controller = Controller(None)
+
+    monkeypatch.setitem(_controller.car_online, VIN, True)
+    monkeypatch.setitem(_controller.car_state, VIN, _mock.data_request_vehicle())
+    _controller.set_id_vin(CAR_ID, VIN)
+    _controller.update_interval = DEFAULT_INTERVAL
+
+    # Test getting interval for specific VIN with it not set
+    assert _controller.get_update_interval_vin(car_id=CAR_ID) == DEFAULT_INTERVAL
+
+    # Test getting interval for specific VIN with it set
+    _controller.set_update_interval_vin(car_id=CAR_ID, value=VIN_INTERVAL)
+    assert _controller.get_update_interval_vin(car_id=CAR_ID) == VIN_INTERVAL
+
+    # Test getting interval when no VIN provided
+    assert _controller.get_update_interval_vin() == DEFAULT_INTERVAL


### PR DESCRIPTION
This PR adds the option for per vehicle polling interval. Through this one can set the polling interval based on each vehicle and thus have a higher polling frequency for 1 vehicle whereas keeping it at a lower polling frequency for another vehicle allowing it to go to sleep.

If no polling interval is set for a VIN then the polling interval is used that has been set for the coordinator.
One can also provide a value of -1 or None as polling interval for a VIN which will then remove that per VIN interval and thus go back to the polling interval for the coordinator.