### PR TITLE
fix: use typing.List for typehint to support python < 3.9

### DIFF
--- a/teslajsonpy/homeassistant/vehicle_data.py
+++ b/teslajsonpy/homeassistant/vehicle_data.py
@@ -7,7 +7,7 @@ https://github.com/zabuldon/teslajsonpy
 """
 import logging
 
-from typing import Optional, Text
+from typing import Optional, Text, List
 from teslajsonpy.homeassistant.vehicle import VehicleDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -72,7 +72,7 @@ class VehicleDataSensor(VehicleDevice):
     def _dict_to_attr(
         cls,
         data: dict,
-        exclude_dicts: Optional[list[str]] = None,
+        exclude_dicts: Optional[List[str]] = None,
         prepend: Optional[str] = None,
     ) -> dict:
         """Convert Tesla returned dict into dict for attributes."""


### PR DESCRIPTION
This fixes a breaking change for users running python 3.8 and lower that was introduced in #299 
Type-hinting the contents of a list require importing `List` from typing on python versions prior to 3.9

Tested with `make coverage` on python 3.8.10