### PR TITLE
Remove duplicate ChargeStateDataSensor

### DIFF
--- a/teslajsonpy/controller.py
+++ b/teslajsonpy/controller.py
@@ -746,7 +746,6 @@ class Controller:
         self.__components.append(VehicleConfigDataSensor(car, self))
         self.__components.append(VehicleDataSensor(car, self))
         self.__components.append(VehicleStateDataSensor(car, self))
-        self.__components.append(ChargeStateDataSensor(car, self))
 
         for seat in ["left", "right", "rear_left", "rear_center", "rear_right"]:
             try:


### PR DESCRIPTION
Sensor ChargeStateDataSensor was added twice to list of components for vehicle resulting in warning within HASS that component is not creating sensors with unique IDs. This did not cause any other issues within HASS.
This PR just removes that duplicate line entry