### PR TITLE
Not all cars have heated steering wheels and seats

### DIFF
--- a/teslajsonpy/homeassistant/heated_seats.py
+++ b/teslajsonpy/homeassistant/heated_seats.py
@@ -70,7 +70,7 @@ class HeatedSeatSelect(VehicleDevice):
         if last_update >= self.__manual_update_time:
             data = self._controller.get_climate_params(self._id)
             self.__seat_heat_level = (
-                data[f"seat_heater_{self.__seat_name}"] if data else None
+                data.get(f"seat_heater_{self.__seat_name}") if data else None
             )
 
     async def set_seat_heat_level(self, level):

--- a/teslajsonpy/homeassistant/heated_steering_wheel.py
+++ b/teslajsonpy/homeassistant/heated_steering_wheel.py
@@ -59,7 +59,7 @@ class HeatedSteeringWheelSwitch(VehicleDevice):
         if last_update >= self.__manual_update_time:
             data = self._controller.get_climate_params(self._id)
             self.__steering_wheel_heated = (
-                data["steering_wheel_heater"] if data else None
+                data.get("steering_wheel_heater") if data else None
             )
 
     async def set_steering_wheel_heat(self, value: bool):


### PR DESCRIPTION
When a car doesn't have a heated steering wheel, teslajsonpy would throw an index error.

simply updating this to a get so it returns None, which is a valid response.

I've also updated heated seats, which used the same code.

Resolves
https://github.com/alandtse/tesla/issues/199