### PR TITLE
Improved handling on 0 Watts spurious power reads

### DIFF
--- a/teslajsonpy/homeassistant/power.py
+++ b/teslajsonpy/homeassistant/power.py
@@ -136,7 +136,11 @@ class PowerSensor(EnergySiteDevice):
         data = self._controller.get_power_params(self._id)
         if data:
             # Note: Some systems that pre-date Tesla aquisition of SolarCity will have `grid_status: Unknown`,
-            # but will have solar power values
+            # but will have solar power values. At the same time, newer systems will report spurious reads of 0 Watts
+            # and grid status unknown. If solar power is 0 return null.
+            if "grid_status" in data and data["grid_status"] == "Unknown" and data["solar_power"] == 0:
+                return
+
             self.__power = data["solar_power"]
             if data["solar_power"] is not None:
                 self.__generating_status = (

--- a/teslajsonpy/homeassistant/power.py
+++ b/teslajsonpy/homeassistant/power.py
@@ -139,6 +139,7 @@ class PowerSensor(EnergySiteDevice):
             # but will have solar power values. At the same time, newer systems will report spurious reads of 0 Watts
             # and grid status unknown. If solar power is 0 return null.
             if "grid_status" in data and data["grid_status"] == "Unknown" and data["solar_power"] == 0:
+                _LOGGER.debug("spurious energy site power read")
                 return
 
             self.__power = data["solar_power"]

--- a/teslajsonpy/homeassistant/power.py
+++ b/teslajsonpy/homeassistant/power.py
@@ -134,6 +134,8 @@ class PowerSensor(EnergySiteDevice):
         """
         super().refresh()
         data = self._controller.get_power_params(self._id)
+        _LOGGER.debug("energy site power refresh")
+
         if data:
             # Note: Some systems that pre-date Tesla aquisition of SolarCity will have `grid_status: Unknown`,
             # but will have solar power values. At the same time, newer systems will report spurious reads of 0 Watts

--- a/teslajsonpy/homeassistant/power.py
+++ b/teslajsonpy/homeassistant/power.py
@@ -134,14 +134,13 @@ class PowerSensor(EnergySiteDevice):
         """
         super().refresh()
         data = self._controller.get_power_params(self._id)
-        _LOGGER.debug("energy site power refresh")
 
         if data:
             # Note: Some systems that pre-date Tesla aquisition of SolarCity will have `grid_status: Unknown`,
             # but will have solar power values. At the same time, newer systems will report spurious reads of 0 Watts
             # and grid status unknown. If solar power is 0 return null.
             if "grid_status" in data and data["grid_status"] == "Unknown" and data["solar_power"] == 0:
-                _LOGGER.debug("spurious energy site power read")
+                _LOGGER.debug("Spurious energy site power read")
                 return
 
             self.__power = data["solar_power"]


### PR DESCRIPTION
Some systems that pre-date Tesla aquisition of SolarCity will have `grid_status: Unknown`, but will have solar power values. At the same time, newer systems will report spurious reads of 0 Watts and grid status "Unknown". In this case, if solar power is 0 return null.

Solves #287 