### PR TITLE
Initial commit to add grid and load sensors

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -17,3 +17,4 @@
 -   giachello [Github](https://github.com/giachello)
 -   danielp370 [Github](https://github.com/danielp370)
 -   carleeno [Github](https://github.com/carleeno)
+-   shred [Github](https://github.com/shred86)

--- a/teslajsonpy/controller.py
+++ b/teslajsonpy/controller.py
@@ -52,7 +52,11 @@ from teslajsonpy.homeassistant.lock import ChargerLock, Lock
 from teslajsonpy.homeassistant.sentry_mode import SentryModeSwitch
 from teslajsonpy.homeassistant.trunk import FrunkLock, TrunkLock
 from teslajsonpy.homeassistant.heated_steering_wheel import HeatedSteeringWheelSwitch
-from teslajsonpy.homeassistant.power import PowerSensor
+from teslajsonpy.homeassistant.power import (
+    SolarPowerSensor,
+    GridPowerSensor,
+    LoadPowerSensor,
+)
 from teslajsonpy.homeassistant.alerts import Horn, FlashLights
 from teslajsonpy.homeassistant.homelink import TriggerHomelink
 from teslajsonpy.homeassistant.vehicle_data import (
@@ -444,6 +448,9 @@ class Controller:
             )
             self.__energysite_type[energysite_id] = energysite["solar_type"]
             self.__power[energysite_id] = {"solar_power": energysite["solar_power"]}
+            # Update energysite dict with site data to get home and grid power
+            energysite.update(await self.get_site_data(energysite_id))
+
             self.__lock[energysite_id] = asyncio.Lock()
             self._add_energysite_components(energysite)
 
@@ -542,6 +549,11 @@ class Controller:
             for p in (await self.api("PRODUCT_LIST"))["response"]
             if p.get("resource_type") == "solar"
         ]
+
+    @backoff.on_exception(min_expo, httpx.RequestError, max_time=10, logger=__name__)
+    async def get_site_data(self, energysite_id: Text) -> None:
+        """Get site data for energy sites."""
+        return (await self.api("SITE_DATA", path_vars={"site_id": energysite_id}))["response"]
 
     @wake_up
     async def post(
@@ -711,7 +723,9 @@ class Controller:
         return self.__components
 
     def _add_energysite_components(self, energysite):
-        self.__components.append(PowerSensor(energysite, self))
+        self.__components.append(SolarPowerSensor(energysite, self))
+        self.__components.append(LoadPowerSensor(energysite, self))
+        self.__components.append(GridPowerSensor(energysite, self))
 
     def _add_car_components(self, car):
         self.__components.append(Climate(car, self))
@@ -1136,7 +1150,7 @@ class Controller:
         return None
 
     def get_power_params(self, site_id: Text) -> Dict:
-        """Return cached copy of charging_params for car_id."""
+        """Return cached copy of power_params for site_id."""
         energysite_id = self._id_to_energysiteid(site_id)
         return self.__power[energysite_id]
 

--- a/teslajsonpy/homeassistant/power.py
+++ b/teslajsonpy/homeassistant/power.py
@@ -35,7 +35,6 @@ class EnergySiteDevice:
         self._id: int = data["id"]
         self._energy_site_id: int = data["energy_site_id"]
         self._site_name: Text = data.get("site_name", f"{self._energy_site_id}")
-        self._solar_type: Text = data["solar_type"]
         self._controller = controller
         self.should_poll: bool = True
         self.type: Text = "device"
@@ -50,26 +49,21 @@ class EnergySiteDevice:
 
     def id(self) -> int:
         # pylint: disable=invalid-name
-        """Return the id of this Vehicle."""
+        """Return the id."""
         return self._id
 
     def energy_site_id(self) -> int:
-        """Return the vehicle_id of this Vehicle."""
+        """Return the energy_site_id."""
         return self._energy_site_id
 
     def site_name(self) -> Text:
-        """Return the car name of this Vehicle."""
+        """Return the site name."""
         return self._site_name
-
-    @property
-    def solar_type(self) -> Text:
-        """Return the type of this Vehicle."""
-        return self._solar_type
 
     async def async_update(
         self, wake_if_asleep: bool = False, force: bool = False
     ) -> None:
-        """Update the vehicle data.
+        """Update the energy site data.
 
         This function will call a controller update.
         """
@@ -80,7 +74,7 @@ class EnergySiteDevice:
 
     # pylint: disable=no-self-use
     def refresh(self) -> None:
-        """Refresh the vehicle data.
+        """Refresh the energy site data.
 
         This assumes the controller has already been updated. This should be
         called by inherited classes so the overall vehicle information is updated.
@@ -111,21 +105,60 @@ class PowerSensor(EnergySiteDevice):
 
         """
         super().__init__(data, controller)
-        self.__power: float = data["solar_power"]
-        self.__generating_status: bool = None
-        self.type = "solar panel"
         self.measurement = "W"
         self.hass_type = "sensor"
         self._device_class: Text = "power"
         self._state_class: Text = "measurement"
-        self.name = self._name()
-        self.uniq_name = self._uniq_name()
         self.bin_type = 0x4
 
     async def async_update(self, wake_if_asleep=False, force=False) -> None:
-        """Update the temperature."""
+        """Update the site info."""
         await super().async_update(wake_if_asleep=wake_if_asleep)
         self.refresh()
+
+    @property
+    def device_class(self) -> Text:
+        """Return the HA device class."""
+        return self._device_class
+
+    @property
+    def state_class(self) -> Text:
+        """Return the HA state class."""
+        return self._state_class
+
+
+class SolarPowerSensor(PowerSensor):
+    """Home-assistant class of power sensors for Tesla Energy Sites (Solar Panels).
+
+    This is intended to be partially inherited by a Home-Assitant entity.
+    """
+
+    def __init__(self, data, controller):
+        """Initialize the solar power sensor."""
+        super().__init__(data, controller)
+        self._solar_type: Text = data["solar_type"]
+        self.__solar_power: float = data["solar_power"]
+        self.__generating_status: bool = None
+        self.type = "solar power"
+        self.name = self._name()
+        self.uniq_name = self._uniq_name()
+
+    def get_value(self) -> float:
+        """Return solar power."""
+        return self.__solar_power
+
+    def get_power(self):
+        """Get solar power."""
+        return self.__solar_power
+
+    def get_generating_status(self):
+        """Get generating status."""
+        return self.__generating_status
+
+    @property
+    def solar_type(self) -> Text:
+        """Return the solar type."""
+        return self._solar_type
 
     def refresh(self) -> None:
         """Refresh data.
@@ -139,34 +172,84 @@ class PowerSensor(EnergySiteDevice):
             # Note: Some systems that pre-date Tesla aquisition of SolarCity will have `grid_status: Unknown`,
             # but will have solar power values. At the same time, newer systems will report spurious reads of 0 Watts
             # and grid status unknown. If solar power is 0 return null.
-            if "grid_status" in data and data["grid_status"] == "Unknown" and data["solar_power"] == 0:
+            if (
+                "grid_status" in data
+                and data["grid_status"] == "Unknown"
+                and data["solar_power"] == 0
+            ):
                 _LOGGER.debug("Spurious energy site power read")
                 return
 
-            self.__power = data["solar_power"]
+            self.__solar_power = data["solar_power"]
             if data["solar_power"] is not None:
                 self.__generating_status = (
                     "Generating" if data["solar_power"] > 0 else "Idle"
                 )
 
+
+class LoadPowerSensor(PowerSensor):
+    """Home-assistant class for load power sensors for Tesla Energy Sites (Solar Panels).
+
+    This is intended to be partially inherited by a Home-Assitant entity.
+    """
+
+    def __init__(self, data, controller):
+        """Initialize the load power sensor."""
+        super().__init__(data, controller)
+        self.__load_power: float = data["load_power"]
+        self.type = "load power"
+        self.name = self._name()
+        self.uniq_name = self._uniq_name()
+
     def get_value(self) -> float:
-        """Return the battery level."""
-        return self.__power
+        """Return load power."""
+        return self.__load_power
 
-    def get_power(self):
-        """Get inside temperature."""
-        return self.__power
+    def get_load_power(self):
+        """Get load power (home consumption)."""
+        return self.__load_power
 
-    def get_generating_status(self):
-        """Get outside temperature."""
-        return self.__generating_status
+    def refresh(self) -> None:
+        """Refresh data.
 
-    @property
-    def device_class(self) -> Text:
-        """Return the HA device class."""
-        return self._device_class
+        This assumes the controller has already been updated
+        """
+        super().refresh()
+        data = self._controller.get_power_params(self._id)
 
-    @property
-    def state_class(self) -> Text:
-        """Return the HA state class."""
-        return self._state_class
+        if data:
+            self.__load_power = data["load_power"]
+
+
+class GridPowerSensor(PowerSensor):
+    """Home-assistant class for grid power sensors for Tesla Energy Sites (Solar Panels).
+
+    This is intended to be partially inherited by a Home-Assitant entity.
+    """
+
+    def __init__(self, data, controller):
+        """Initialize the grid power sensor."""
+        super().__init__(data, controller)
+        self.__grid_power: float = data["grid_power"]
+        self.type = "grid power"
+        self.name = self._name()
+        self.uniq_name = self._uniq_name()
+
+    def get_value(self) -> float:
+        """Return grid power."""
+        return self.__grid_power
+
+    def get_grid_power(self):
+        """Get grid power (grid import/export)."""
+        return self.__grid_power
+
+    def refresh(self) -> None:
+        """Refresh data.
+
+        This assumes the controller has already been updated
+        """
+        super().refresh()
+        data = self._controller.get_power_params(self._id)
+
+        if data:
+            self.__grid_power = data["grid_power"]

--- a/tests/tesla_mock.py
+++ b/tests/tesla_mock.py
@@ -470,17 +470,41 @@ VEHICLE = {
     "vehicle_config": None,
 }
 
+# Example config for solar only (no powerall) and Neurio
+# Combination of PRODUCT_LIST and SITE_DATA from Controller
 ENERGYSITE_CONFIG = {
-    "id": 12345678901234567,
-    "energy_site_id": 1234567890,
-    "asset_site_id": 1234567890,
-    "resource_type": "solar",
-    "site_name": "Test Site",
-    "solar_type": "pv_panels",
-    "solar_power": None,
-    "sync_grid_alert_enabled": False,
-    "breaker_alert_enabled": False,
-}
+    'energy_site_id': 1234567890,
+    'resource_type': 'solar',
+    'id': 'c31d46d3-d3f3-4319-a2cb-34719c30243d',
+    'asset_site_id': '3f345132-3c13-2cda-351a-341fq3a2dab2', 
+    'solar_power': 4230, 
+    'solar_type': 'pv_panel', 
+    'storm_mode_enabled': None, 
+    'powerwall_onboarding_settings_set': None, 
+    'sync_grid_alert_enabled': False, 
+    'breaker_alert_enabled': False, 
+    'components': {
+        'battery': False, 
+        'solar': True, 
+        'solar_type': 'pv_panel', 
+        'grid': True, 
+        'load_meter': True, 
+        'market_type': 'residential'
+        }, 
+    'energy_left': 0, 
+    'total_pack_energy': 1, 
+    'percentage_charged': 0, 
+    'battery_power': 0, 
+    'load_power': 3245.4599609375, 
+    'grid_status': 'Unknown', 
+    'grid_services_active': False, 
+    'grid_power': -984.5400390625, 
+    'grid_services_power': 0, 
+    'generator_power': 0, 
+    'island_status': 'island_status_unknown', 
+    'storm_mode_active': False, 
+    'timestamp': '2022-07-29T23:02:14Z', 
+    'wall_connectors': None}
 
 ENERGYSITE_CONFIG_NO_NAME = {
     "id": 12345678901234567,
@@ -494,10 +518,22 @@ ENERGYSITE_CONFIG_NO_NAME = {
 }
 
 ENERGYSITE_STATE = {
-    "id": 12345678901234567,
-    "timestamp": "2011-01-01",
-    "solar_power": 1900,
-}
+    "solar_power": 7720,
+    "energy_left": 0,
+    "total_pack_energy": 1,
+    "percentage_charged": 0,
+    "battery_power": 0,
+    "load_power": 4517.14990234375,
+    "grid_status": "Unknown",
+    "grid_services_active": False,
+    "grid_power": -3202.85009765625,
+    "grid_services_power": 0,
+    "generator_power": 0,
+    "island_status": "island_status_unknown",
+    "storm_mode_active": False,
+    "timestamp": "2022-07-28T17:11:27Z",
+    "wall_connectors": None
+  }
 
 ENERGYSITE_STATE_UNKNOWN_GRID = {
     "id": 12345678901234567,

--- a/tests/unit_tests/homeassistant/test_power_sensor.py
+++ b/tests/unit_tests/homeassistant/test_power_sensor.py
@@ -3,7 +3,7 @@
 import pytest
 
 from teslajsonpy.controller import Controller
-from teslajsonpy.homeassistant.power import PowerSensor
+from teslajsonpy.homeassistant.power import PowerSensor, SolarPowerSensor, LoadPowerSensor, GridPowerSensor
 
 from tests.tesla_mock import TeslaMock
 
@@ -19,6 +19,18 @@ def test_device_class(monkeypatch):
 
     assert _sensor.device_class == "power"
 
+    _sensor = SolarPowerSensor(_data, _controller)
+
+    assert _sensor.type == "solar power"
+
+    _sensor = LoadPowerSensor(_data, _controller)
+
+    assert _sensor.type == "load power"
+
+    _sensor = GridPowerSensor(_data, _controller)
+
+    assert _sensor.type == "grid power"
+
 def test_device_no_name(monkeypatch):
     """Test device_class()."""
 
@@ -31,35 +43,92 @@ def test_device_no_name(monkeypatch):
     assert _sensor.site_name() == "1234567890"
 
 
-def test_get_power_on_init(monkeypatch):
+def test_get_solar_power_on_init(monkeypatch):
     """Test get_power() after initialization."""
 
     _mock = TeslaMock(monkeypatch)
     _controller = Controller(None)
 
     _data = _mock.data_request_energy_site()
-    _sensor = PowerSensor(_data, _controller)
+    _sensor = SolarPowerSensor(_data, _controller)
 
     assert _sensor is not None
-    assert _sensor.get_power() is None
+    assert _sensor.get_power() == 4230
 
+def test_get_load_power_on_init(monkeypatch):
+    """Test get_load_power() after initialization."""
+
+    _mock = TeslaMock(monkeypatch)
+    _controller = Controller(None)
+
+    _data = _mock.data_request_energy_site()
+    _sensor = LoadPowerSensor(_data, _controller)
+
+    assert _sensor is not None
+    assert _sensor.get_load_power() == 3245.4599609375
+
+def test_get_grid_power_on_init(monkeypatch):
+    """Test get_grid_power() after initialization."""
+
+    _mock = TeslaMock(monkeypatch)
+    _controller = Controller(None)
+
+    _data = _mock.data_request_energy_site()
+    _sensor = GridPowerSensor(_data, _controller)
+
+    assert _sensor is not None
+    assert _sensor.get_grid_power() == -984.5400390625
 
 @pytest.mark.asyncio
 async def test_get_power_after_update(monkeypatch):
-    """Test get_power()  after an update."""
+    """Test get_power() after an update."""
 
     _mock = TeslaMock(monkeypatch)
     _controller = Controller(None)
 
     _data = _mock.data_request_energy_site()
     _data["solar_power"] = 1800
-    _sensor = PowerSensor(_data, _controller)
+    _sensor = SolarPowerSensor(_data, _controller)
 
     await _sensor.async_update()
 
     assert _sensor is not None
     assert not _sensor.get_power() is None
-    assert _sensor.get_power() == 1900
+    assert _sensor.get_power() == 7720
+
+@pytest.mark.asyncio
+async def test_get_load_power_after_update(monkeypatch):
+    """Test get_load_power() after an update."""
+
+    _mock = TeslaMock(monkeypatch)
+    _controller = Controller(None)
+
+    _data = _mock.data_request_energy_site()
+    _data["load_power"] = 1800
+    _sensor = LoadPowerSensor(_data, _controller)
+
+    await _sensor.async_update()
+
+    assert _sensor is not None
+    assert not _sensor.get_load_power() is None
+    assert _sensor.get_load_power() == 4517.14990234375
+
+@pytest.mark.asyncio
+async def test_get_grid_power_after_update(monkeypatch):
+    """Test get_grid_power() after an update."""
+
+    _mock = TeslaMock(monkeypatch)
+    _controller = Controller(None)
+
+    _data = _mock.data_request_energy_site()
+    _data["grid_power"] = 1800
+    _sensor = GridPowerSensor(_data, _controller)
+
+    await _sensor.async_update()
+
+    assert _sensor is not None
+    assert not _sensor.get_grid_power() is None
+    assert _sensor.get_grid_power() == -3202.85009765625
 
 @pytest.mark.asyncio
 async def test_get_power_after_update_with_unknown_status(monkeypatch):
@@ -73,7 +142,7 @@ async def test_get_power_after_update_with_unknown_status(monkeypatch):
 
     _data = _mock.data_request_energy_site()
     _data["solar_power"] = 1800
-    _sensor = PowerSensor(_data, _controller)
+    _sensor = SolarPowerSensor(_data, _controller)
 
     await _sensor.async_update()
 


### PR DESCRIPTION
Initial commit to add grid and home (aka load) sensors for Tesla solar systems. All Tesla solar customers with Powerwall should have grid and home reporting as well as non-Powerwall customers with a Tesla inverter and Neurio energy monitoring device, which is what I have. Not all non-Powerwall customers will have a Neurio energy monitoring device as Tesla is not consistent on when they install them. However, I suspect the JSON structure is the same but they will just report back with a value of 0.

Specific changes:
- ~~Added new method `get_site_data` to controller.py. This uses the `SITE_DATA` endpoint where the grid and load power values are located.~~
- ~~During initialization of `Controller`, call `get_site_data` and append it with the `PRODUCT_LIST`~~ Add `load_power` and `grid_power` to `energysite` dictionary so we have valid and correct grid and lower power values when the new `GridPowerSensor` and `LoadPowerSensor` classes are instantiated. Actual values update almost immediately after initialization when `refresh` is called. 
- Created three new classes, `SolarPowerSensor`, `GridPowerSensor` and `LoadPowerSensor`. I kept `PowerSensor` as a parent class to inherit from since the three new power sensors share some attributes.
- Added tests for new code additions.
- Updated some doc strings that I randomly saw were incorrect.