### PR TITLE
Revert name to prevent breaking change

### DIFF
--- a/teslajsonpy/homeassistant/power.py
+++ b/teslajsonpy/homeassistant/power.py
@@ -134,12 +134,12 @@ class SolarPowerSensor(PowerSensor):
     """
 
     def __init__(self, data, controller):
-        """Initialize the solar power sensor."""
+        """Initialize the solar panel sensor."""
         super().__init__(data, controller)
         self._solar_type: Text = data["solar_type"]
         self.__solar_power: float = data["solar_power"]
         self.__generating_status: bool = None
-        self.type = "solar power"
+        self.type = "solar panel"
         self.name = self._name()
         self.uniq_name = self._uniq_name()
 

--- a/tests/unit_tests/homeassistant/test_power_sensor.py
+++ b/tests/unit_tests/homeassistant/test_power_sensor.py
@@ -21,7 +21,7 @@ def test_device_class(monkeypatch):
 
     _sensor = SolarPowerSensor(_data, _controller)
 
-    assert _sensor.type == "solar power"
+    assert _sensor.type == "solar panel"
 
     _sensor = LoadPowerSensor(_data, _controller)
 


### PR DESCRIPTION
Apologize I didn't catch this earlier but the only reason the previous solar panel sensor was being recreated was because I updated the name to match the naming convention of the other sensors. The name is used as a part of the UUID in Home Assistant which was causing a new solar power sensor to be created. I just reverted back to the original name, solar panel, so it doesn't create a breaking change.