### PR TITLE
Fix grid status and load sensor issues

### DIFF
--- a/teslajsonpy/controller.py
+++ b/teslajsonpy/controller.py
@@ -30,7 +30,7 @@ from teslajsonpy.const import (
     SLEEP_INTERVAL,
     TESLA_PRODUCT_TYPE_ENERGY_SITES,
     TESLA_PRODUCT_TYPE_VEHICLES,
-    TESLA_DEFAULT_ENERGY_SITE_NAME
+    TESLA_DEFAULT_ENERGY_SITE_NAME,
 )
 from teslajsonpy.exceptions import should_giveup, RetryLimitError, TeslaException
 from teslajsonpy.homeassistant.battery_sensor import Battery, Range
@@ -379,6 +379,7 @@ class Controller:
         self.polling_policy = polling_policy
         self.__energysite_name = {}
         self.__energysite_type = {}
+        self._grid_status = {}
         self.__power = {}
         self.energysites = {}
         self.__id_energysiteid_map = {}
@@ -457,6 +458,8 @@ class Controller:
             )
             self.__energysite_type[energysite_id] = energysite["solar_type"]
             self.__power[energysite_id] = {"solar_power": energysite["solar_power"]}
+            # Default to True but will be checked in first update
+            self._grid_status[energysite_id] = {"grid_always_unk": True}
 
             self.__lock[energysite_id] = asyncio.Lock()
             self._add_energysite_components(energysite)
@@ -560,8 +563,9 @@ class Controller:
     @backoff.on_exception(min_expo, httpx.RequestError, max_time=10, logger=__name__)
     async def get_site_config(self, energysite_id):
         """Get site config json from TeslaAPI."""
-        return (await self.api("SITE_CONFIG",
-                               path_vars={"site_id": energysite_id}))["response"]
+        return (await self.api("SITE_CONFIG", path_vars={"site_id": energysite_id}))[
+            "response"
+        ]
 
     @wake_up
     async def post(
@@ -732,8 +736,9 @@ class Controller:
 
     def _add_energysite_components(self, energysite):
         self.__components.append(SolarPowerSensor(energysite, self))
-        self.__components.append(LoadPowerSensor(energysite, self))
-        self.__components.append(GridPowerSensor(energysite, self))
+        if energysite["components"]["load_meter"]:
+            self.__components.append(LoadPowerSensor(energysite, self))
+            self.__components.append(GridPowerSensor(energysite, self))
 
     def _add_car_components(self, car):
         self.__components.append(Climate(car, self))
@@ -983,6 +988,9 @@ class Controller:
                     data = None
                 if data and data["response"]:
                     response = data["response"]
+                    if response["grid_status"] == "Active":
+                        self._grid_status[energysite_id]["grid_always_unk"] = False
+
                     self.__power[energysite_id] = response
 
         async with self.__update_lock:

--- a/teslajsonpy/controller.py
+++ b/teslajsonpy/controller.py
@@ -736,7 +736,7 @@ class Controller:
 
     def _add_energysite_components(self, energysite):
         self.__components.append(SolarPowerSensor(energysite, self))
-        if energysite["components"]["load_meter"]:
+        if energysite.get("components").get("load_meter"):
             self.__components.append(LoadPowerSensor(energysite, self))
             self.__components.append(GridPowerSensor(energysite, self))
 

--- a/teslajsonpy/homeassistant/power.py
+++ b/teslajsonpy/homeassistant/power.py
@@ -198,7 +198,7 @@ class LoadPowerSensor(PowerSensor):
     def __init__(self, data, controller):
         """Initialize the load power sensor."""
         super().__init__(data, controller)
-        self.__load_power: float = data["load_power"]
+        self.__load_power: float = data.get("load_power")
         self.type = "load power"
         self.name = self._name()
         self.uniq_name = self._uniq_name()
@@ -220,7 +220,7 @@ class LoadPowerSensor(PowerSensor):
         data = self._controller.get_power_params(self._id)
 
         if data:
-            self.__load_power = data["load_power"]
+            self.__load_power = data.get("load_power")
 
 
 class GridPowerSensor(PowerSensor):
@@ -232,7 +232,7 @@ class GridPowerSensor(PowerSensor):
     def __init__(self, data, controller):
         """Initialize the grid power sensor."""
         super().__init__(data, controller)
-        self.__grid_power: float = data["grid_power"]
+        self.__grid_power: float = data.get("grid_power")
         self.type = "grid power"
         self.name = self._name()
         self.uniq_name = self._uniq_name()
@@ -254,4 +254,4 @@ class GridPowerSensor(PowerSensor):
         data = self._controller.get_power_params(self._id)
 
         if data:
-            self.__grid_power = data["grid_power"]
+            self.__grid_power = data.get("grid_power")

--- a/teslajsonpy/homeassistant/power.py
+++ b/teslajsonpy/homeassistant/power.py
@@ -141,6 +141,7 @@ class SolarPowerSensor(PowerSensor):
         self._solar_type: Text = data["solar_type"]
         self.__solar_power: float = data["solar_power"]
         self.__generating_status: bool = None
+        self.__grid_status: dict = controller._grid_status[self._energy_site_id]
         self.type = "solar panel"
         self.name = self._name()
         self.uniq_name = self._uniq_name()
@@ -174,15 +175,14 @@ class SolarPowerSensor(PowerSensor):
             # Note: Some systems that pre-date Tesla aquisition of SolarCity will have `grid_status: Unknown`,
             # but will have solar power values. At the same time, newer systems will report spurious reads of 0 Watts
             # and grid status unknown. If solar power is 0 return null.
-            if (
-                "grid_status" in data
-                and data["grid_status"] == "Unknown"
-                and data["solar_power"] == 0
+            if not self.__grid_status["grid_always_unk"] and (
+                data["grid_status"] == "Unknown" and data["solar_power"] == 0
             ):
                 _LOGGER.debug("Spurious energy site power read")
                 return
 
             self.__solar_power = data["solar_power"]
+
             if data["solar_power"] is not None:
                 self.__generating_status = (
                     "Generating" if data["solar_power"] > 0 else "Idle"

--- a/tests/unit_tests/homeassistant/test_power_sensor.py
+++ b/tests/unit_tests/homeassistant/test_power_sensor.py
@@ -3,7 +3,12 @@
 import pytest
 
 from teslajsonpy.controller import Controller
-from teslajsonpy.homeassistant.power import PowerSensor, SolarPowerSensor, LoadPowerSensor, GridPowerSensor
+from teslajsonpy.homeassistant.power import (
+    PowerSensor,
+    SolarPowerSensor,
+    LoadPowerSensor,
+    GridPowerSensor,
+)
 
 from tests.tesla_mock import TeslaMock
 
@@ -13,6 +18,7 @@ def test_device_class(monkeypatch):
 
     _mock = TeslaMock(monkeypatch)
     _controller = Controller(None)
+    _controller._grid_status = {1234567890: {"grid_always_unk": True}}
 
     _data = _mock.data_request_energy_site()
     _sensor = PowerSensor(_data, _controller)
@@ -34,6 +40,7 @@ def test_device_class(monkeypatch):
     assert _sensor.type == "grid power"
     assert _sensor.name == "My Home grid power"
 
+
 def test_site_with_name(monkeypatch):
     """Test site with no site_name in json data."""
 
@@ -44,6 +51,7 @@ def test_site_with_name(monkeypatch):
     _sensor = PowerSensor(_data, _controller)
 
     assert _sensor.site_name() == "My Home"
+
 
 def test_site_without_name(monkeypatch):
     """Test site with no site_name in json data."""
@@ -56,17 +64,20 @@ def test_site_without_name(monkeypatch):
 
     assert _sensor.site_name() == "My Home"
 
+
 def test_get_solar_power_on_init(monkeypatch):
     """Test get_power() after initialization."""
 
     _mock = TeslaMock(monkeypatch)
     _controller = Controller(None)
+    _controller._grid_status = {1234567890: {"grid_always_unk": True}}
 
     _data = _mock.data_request_energy_site()
     _sensor = SolarPowerSensor(_data, _controller)
 
     assert _sensor is not None
     assert _sensor.get_power() == 4230
+
 
 def test_get_load_power_on_init(monkeypatch):
     """Test get_load_power() after initialization."""
@@ -80,6 +91,7 @@ def test_get_load_power_on_init(monkeypatch):
     assert _sensor is not None
     assert _sensor.get_load_power() == 3245.4599609375
 
+
 def test_get_grid_power_on_init(monkeypatch):
     """Test get_grid_power() after initialization."""
 
@@ -92,12 +104,14 @@ def test_get_grid_power_on_init(monkeypatch):
     assert _sensor is not None
     assert _sensor.get_grid_power() == -984.5400390625
 
+
 @pytest.mark.asyncio
 async def test_get_power_after_update(monkeypatch):
     """Test get_power() after an update."""
 
     _mock = TeslaMock(monkeypatch)
     _controller = Controller(None)
+    _controller._grid_status = {1234567890: {"grid_always_unk": True}}
 
     _data = _mock.data_request_energy_site()
     _data["solar_power"] = 1800
@@ -108,6 +122,7 @@ async def test_get_power_after_update(monkeypatch):
     assert _sensor is not None
     assert not _sensor.get_power() is None
     assert _sensor.get_power() == 7720
+
 
 @pytest.mark.asyncio
 async def test_get_load_power_after_update(monkeypatch):
@@ -126,6 +141,7 @@ async def test_get_load_power_after_update(monkeypatch):
     assert not _sensor.get_load_power() is None
     assert _sensor.get_load_power() == 4517.14990234375
 
+
 @pytest.mark.asyncio
 async def test_get_grid_power_after_update(monkeypatch):
     """Test get_grid_power() after an update."""
@@ -143,6 +159,7 @@ async def test_get_grid_power_after_update(monkeypatch):
     assert not _sensor.get_grid_power() is None
     assert _sensor.get_grid_power() == -3202.85009765625
 
+
 @pytest.mark.asyncio
 async def test_get_power_after_update_with_unknown_status(monkeypatch):
     """Test get_power()  after an update with an unknown grid status."""
@@ -152,6 +169,7 @@ async def test_get_power_after_update_with_unknown_status(monkeypatch):
         Controller, "get_power_params", _mock.mock_get_power_unknown_grid_params
     )
     _controller = Controller(None)
+    _controller._grid_status = {1234567890: {"grid_always_unk": True}}
 
     _data = _mock.data_request_energy_site()
     _data["solar_power"] = 1800


### PR DESCRIPTION
Fixes:
- Fixes [key error issue](https://github.com/alandtse/tesla/issues/254) for energy sites that don't have load meters. Added a check to not add the grid and load sensor unless `load_meter` is `True` from Tesla's API response.
- Adds some checks to deal with the [issue](https://github.com/alandtse/tesla/issues/248) where some energy sites don't report `grid_status` (i.e. always `Unknown`) and other sites do but with spurious power readings at times.




