### PR TITLE
Fix for grid_status case

### DIFF
--- a/teslajsonpy/controller.py
+++ b/teslajsonpy/controller.py
@@ -988,7 +988,10 @@ class Controller:
                     data = None
                 if data and data["response"]:
                     response = data["response"]
-                    if response["grid_status"] == "Active":
+                    if (
+                        "grid_status" not in response
+                        or response.get("grid_status") != "Unknown"
+                    ):
                         self._grid_status[energysite_id]["grid_always_unk"] = False
 
                     self.__power[energysite_id] = response

--- a/teslajsonpy/homeassistant/power.py
+++ b/teslajsonpy/homeassistant/power.py
@@ -176,16 +176,16 @@ class SolarPowerSensor(PowerSensor):
             # but will have solar power values. At the same time, newer systems will report spurious reads of 0 Watts
             # and grid status unknown. If solar power is 0 return null.
             if not self.__grid_status["grid_always_unk"] and (
-                data["grid_status"] == "Unknown" and data["solar_power"] == 0
+                data.get("grid_status") == "Unknown" and data.get("solar_power") == 0
             ):
                 _LOGGER.debug("Spurious energy site power read")
                 return
 
-            self.__solar_power = data["solar_power"]
+            self.__solar_power = data.get("solar_power")
 
-            if data["solar_power"] is not None:
+            if data.get("solar_power") is not None:
                 self.__generating_status = (
-                    "Generating" if data["solar_power"] > 0 else "Idle"
+                    "Generating" if data.get("solar_power") > 0 else "Idle"
                 )
 
 

--- a/teslajsonpy/homeassistant/power.py
+++ b/teslajsonpy/homeassistant/power.py
@@ -138,8 +138,8 @@ class SolarPowerSensor(PowerSensor):
     def __init__(self, data, controller):
         """Initialize the solar panel sensor."""
         super().__init__(data, controller)
-        self._solar_type: Text = data["solar_type"]
-        self.__solar_power: float = data["solar_power"]
+        self._solar_type: Text = data.get("solar_type")
+        self.__solar_power: float = data.get("solar_power")
         self.__generating_status: bool = None
         self.__grid_status: dict = controller._grid_status[self._energy_site_id]
         self.type = "solar panel"
@@ -183,9 +183,9 @@ class SolarPowerSensor(PowerSensor):
 
             self.__solar_power = data.get("solar_power")
 
-            if data.get("solar_power") is not None:
+            if self.__solar_power is not None:
                 self.__generating_status = (
-                    "Generating" if data.get("solar_power") > 0 else "Idle"
+                    "Generating" if self.__solar_power > 0 else "Idle"
                 )
 
 


### PR DESCRIPTION
Fixes an issue that was identified where `grid_status` is actually not reported when the state is `Active` in certain setups.

Sorry for all the changes @alandtse. Not having JSON responses on the various energy site setups and cases is proving to be a pain.