### PR TITLE
feat: Add window control and window binary sensor

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -18,3 +18,4 @@
 -   danielp370 [Github](https://github.com/danielp370)
 -   carleeno [Github](https://github.com/carleeno)
 -   shred [Github](https://github.com/shred86)
+-   InTheDaylight14 [Github](https://github.com/InTheDaylight14)

--- a/teslajsonpy/car.py
+++ b/teslajsonpy/car.py
@@ -546,8 +546,8 @@ class TeslaCar:
             or self._vehicle_data.get("vehicle_state", {}).get("rd_window")
             or self._vehicle_data.get("vehicle_state", {}).get("rp_window")
         ):
-            return 1
-        return 0
+            return True
+        return False
 
     async def _send_command(
         self, name: str, *, path_vars: dict, wake_if_asleep: bool = False, **kwargs
@@ -988,8 +988,8 @@ class TeslaCar:
             "WINDOW_CONTROL",
             path_vars={"vehicle_id": self.id},
             command="close",
-            lat=0,
-            long=0,
+            lat=self.latitude,
+            long=self.longitude,
             wake_if_asleep=True,
         )
         if data and data["response"]["result"] is True:

--- a/teslajsonpy/car.py
+++ b/teslajsonpy/car.py
@@ -547,8 +547,7 @@ class TeslaCar:
             or self._vehicle_data.get("vehicle_state", {}).get("rp_window")
         ):
             return 1
-        else:
-            return 0
+        return 0
 
     async def _send_command(
         self, name: str, *, path_vars: dict, wake_if_asleep: bool = False, **kwargs
@@ -965,7 +964,7 @@ class TeslaCar:
             self._vehicle_data["vehicle_state"].update(params)
 
     async def vent_windows(self) -> None:
-        """Vent Windows"""
+        """Vent Windows."""
         data = await self._send_command(
             "WINDOW_CONTROL",
             path_vars={"vehicle_id": self.id},
@@ -984,7 +983,7 @@ class TeslaCar:
             self._vehicle_data["vehicle_state"].update(params)
 
     async def close_windows(self) -> None:
-        """Close Windows"""
+        """Close Windows."""
         data = await self._send_command(
             "WINDOW_CONTROL",
             path_vars={"vehicle_id": self.id},

--- a/teslajsonpy/car.py
+++ b/teslajsonpy/car.py
@@ -537,6 +537,19 @@ class TeslaCar:
         """Return rear passenger window status."""
         return self._vehicle_data.get("vehicle_state", {}).get("rp_window")
 
+    @property
+    def is_window_open(self) -> bool:
+        """Return car is window open."""
+        if (
+            self._vehicle_data.get("vehicle_state", {}).get("fd_window")
+            or self._vehicle_data.get("vehicle_state", {}).get("fp_window")
+            or self._vehicle_data.get("vehicle_state", {}).get("rd_window")
+            or self._vehicle_data.get("vehicle_state", {}).get("rp_window")
+        ):
+            return 1
+        else:
+            return 0
+
     async def _send_command(
         self, name: str, *, path_vars: dict, wake_if_asleep: bool = False, **kwargs
     ) -> dict:
@@ -949,4 +962,42 @@ class TeslaCar:
         )
         if data and data["response"]["result"] is True:
             params = {"locked": False}
+            self._vehicle_data["vehicle_state"].update(params)
+
+    async def vent_windows(self) -> None:
+        """Vent Windows"""
+        data = await self._send_command(
+            "WINDOW_CONTROL",
+            path_vars={"vehicle_id": self.id},
+            command="vent",
+            lat=0,
+            long=0,
+            wake_if_asleep=True,
+        )
+        if data and data["response"]["result"] is True:
+            params = {
+                "fd_window": 1,
+                "fp_window": 1,
+                "rd_window": 1,
+                "rp_window": 1,
+            }
+            self._vehicle_data["vehicle_state"].update(params)
+
+    async def close_windows(self) -> None:
+        """Close Windows"""
+        data = await self._send_command(
+            "WINDOW_CONTROL",
+            path_vars={"vehicle_id": self.id},
+            command="close",
+            lat=0,
+            long=0,
+            wake_if_asleep=True,
+        )
+        if data and data["response"]["result"] is True:
+            params = {
+                "fd_window": 0,
+                "fp_window": 0,
+                "rd_window": 0,
+                "rp_window": 0,
+            }
             self._vehicle_data["vehicle_state"].update(params)

--- a/teslajsonpy/car.py
+++ b/teslajsonpy/car.py
@@ -538,16 +538,16 @@ class TeslaCar:
         return self._vehicle_data.get("vehicle_state", {}).get("rp_window")
 
     @property
-    def is_window_open(self) -> bool:
-        """Return car is window open."""
+    def is_window_closed(self) -> bool:
+        """Return all car windows are close."""
         if (
             self._vehicle_data.get("vehicle_state", {}).get("fd_window")
             or self._vehicle_data.get("vehicle_state", {}).get("fp_window")
             or self._vehicle_data.get("vehicle_state", {}).get("rd_window")
             or self._vehicle_data.get("vehicle_state", {}).get("rp_window")
         ):
-            return True
-        return False
+            return False
+        return True
 
     async def _send_command(
         self, name: str, *, path_vars: dict, wake_if_asleep: bool = False, **kwargs

--- a/tests/unit_tests/test_car.py
+++ b/tests/unit_tests/test_car.py
@@ -169,6 +169,8 @@ async def test_car_properties(monkeypatch):
 
     assert _car.is_on
 
+    assert _car.is_window_open
+
     assert _car.longitude == VEHICLE_DATA["drive_state"]["longitude"]
 
     assert _car.latitude == VEHICLE_DATA["drive_state"]["latitude"]
@@ -497,3 +499,27 @@ async def test_unlock(monkeypatch):
     _car = _controller.cars[VIN]
 
     assert await _car.unlock() is None
+
+
+@pytest.mark.asyncio
+async def test_vent_windows(monkeypatch):
+    """Test vent windows."""
+    TeslaMock(monkeypatch)
+    _controller = Controller(None)
+    await _controller.connect()
+    await _controller.generate_car_objects()
+    _car = _controller.cars[VIN]
+
+    assert await _car.vent_windows()() is None
+
+
+@pytest.mark.asyncio
+async def test_close_windows(monkeypatch):
+    """Test close windows."""
+    TeslaMock(monkeypatch)
+    _controller = Controller(None)
+    await _controller.connect()
+    await _controller.generate_car_objects()
+    _car = _controller.cars[VIN]
+
+    assert await _car.close_windows()() is None

--- a/tests/unit_tests/test_car.py
+++ b/tests/unit_tests/test_car.py
@@ -169,7 +169,7 @@ async def test_car_properties(monkeypatch):
 
     assert _car.is_on
 
-    assert _car.is_window_open
+    assert _car.is_window_open == VEHICLE_DATA["vehicle_state"]["fd_window"]
 
     assert _car.longitude == VEHICLE_DATA["drive_state"]["longitude"]
 
@@ -502,7 +502,7 @@ async def test_unlock(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_vent_windows(monkeypatch):
+async def test_vent_window(monkeypatch):
     """Test vent windows."""
     TeslaMock(monkeypatch)
     _controller = Controller(None)
@@ -510,11 +510,11 @@ async def test_vent_windows(monkeypatch):
     await _controller.generate_car_objects()
     _car = _controller.cars[VIN]
 
-    assert await _car.vent_windows()() is None
+    assert await _car.vent_window() is None
 
 
 @pytest.mark.asyncio
-async def test_close_windows(monkeypatch):
+async def test_close_window(monkeypatch):
     """Test close windows."""
     TeslaMock(monkeypatch)
     _controller = Controller(None)
@@ -522,4 +522,4 @@ async def test_close_windows(monkeypatch):
     await _controller.generate_car_objects()
     _car = _controller.cars[VIN]
 
-    assert await _car.close_windows()() is None
+    assert await _car.close_window() is None

--- a/tests/unit_tests/test_car.py
+++ b/tests/unit_tests/test_car.py
@@ -502,7 +502,7 @@ async def test_unlock(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_vent_window(monkeypatch):
+async def test_vent_windows(monkeypatch):
     """Test vent windows."""
     TeslaMock(monkeypatch)
     _controller = Controller(None)
@@ -510,11 +510,11 @@ async def test_vent_window(monkeypatch):
     await _controller.generate_car_objects()
     _car = _controller.cars[VIN]
 
-    assert await _car.vent_window() is None
+    assert await _car.vent_windows() is None
 
 
 @pytest.mark.asyncio
-async def test_close_window(monkeypatch):
+async def test_close_windows(monkeypatch):
     """Test close windows."""
     TeslaMock(monkeypatch)
     _controller = Controller(None)
@@ -522,4 +522,4 @@ async def test_close_window(monkeypatch):
     await _controller.generate_car_objects()
     _car = _controller.cars[VIN]
 
-    assert await _car.close_window() is None
+    assert await _car.close_windows() is None

--- a/tests/unit_tests/test_car.py
+++ b/tests/unit_tests/test_car.py
@@ -169,7 +169,7 @@ async def test_car_properties(monkeypatch):
 
     assert _car.is_on
 
-    assert _car.is_window_open == VEHICLE_DATA["vehicle_state"]["fd_window"]
+    assert _car.is_window_closed
 
     assert _car.longitude == VEHICLE_DATA["drive_state"]["longitude"]
 


### PR DESCRIPTION
This PR adds a is_window_open parameter that will return 1 if any window is open. It also adds a close_windows and vent_windows function. This has been working from Home Assistant with the custom_api calls. 

I need to figure out how to run the tests. ~~"make init" in terminal did not recognize "make". Any guidance on the tests or the code is appreciated.~~

~~Got make installed fine, receiving this error "Expecting value: line 1 column 1 (char 0)". I'll keep poking.~~

All good now, tests are working on my end. 