### PR TITLE
feat: Add usable_battery_level method in TeslaCar

### DIFF
--- a/teslajsonpy/car.py
+++ b/teslajsonpy/car.py
@@ -85,8 +85,13 @@ class TeslaCar:
 
     @property
     def battery_level(self) -> float:
-        """Return car battery level."""
+        """Return car battery level (SOC). This is not affected by temperature."""
         return self._vehicle_data.get("charge_state", {}).get("battery_level")
+
+    @property
+    def usable_battery_level(self) -> float:
+        """Return car usable battery level (uSOE). This is the value used in the app and car."""
+        return self._vehicle_data.get("charge_state", {}).get("usable_battery_level")
 
     @property
     def battery_range(self) -> float:

--- a/tests/tesla_mock.py
+++ b/tests/tesla_mock.py
@@ -428,7 +428,7 @@ VEHICLE_DATA = {
         "time_to_full_charge": 0.25,
         "timestamp": 1661641175268,
         "trip_charging": False,
-        "usable_battery_level": 78,
+        "usable_battery_level": 77,
         "user_charge_enable_request": None,
     },
     "climate_state": {
@@ -653,7 +653,7 @@ VEHICLE_DATA_BY_VIN = {
             "time_to_full_charge": 0.25,
             "timestamp": 1661641175268,
             "trip_charging": False,
-            "usable_battery_level": 78,
+            "usable_battery_level": 77,
             "user_charge_enable_request": None,
         },
         "climate_state": {

--- a/tests/unit_tests/test_car.py
+++ b/tests/unit_tests/test_car.py
@@ -38,6 +38,8 @@ async def test_car_properties(monkeypatch):
 
     assert _car.battery_level == VEHICLE_DATA["charge_state"]["battery_level"]
 
+    assert _car.usable_battery_level == VEHICLE_DATA["charge_state"]["usable_battery_level"]
+
     assert _car.battery_range == VEHICLE_DATA["charge_state"]["battery_range"]
 
     assert (


### PR DESCRIPTION
For https://github.com/alandtse/tesla/issues/359

This PR adds a `usable_battery_level` method in `TeslaCar`. The official Tesla app and in-car display shows the usable battery level value, which is affected by temperature (apparent when you see a snowflake icon). By adding this method, we can update the HA integration to use this new method for the car's battery level sensor so that it matches the official app.