### PR TITLE
fix: correctly represent online and asleep states according to API

### DIFF
--- a/teslajsonpy/const.py
+++ b/teslajsonpy/const.py
@@ -30,3 +30,9 @@ PRODUCT_TYPE_POWERWALLS = "powerwalls"
 RESOURCE_TYPE = "resource_type"
 RESOURCE_TYPE_SOLAR = "solar"
 RESOURCE_TYPE_BATTERY = "battery"
+
+STATUS_ONLINE = "online"  # reported by Tesla, vehicle available and awake
+STATUS_ASLEEP = "asleep"  # reported by Tesla, vehicle available but asleep
+STATUS_OFFLINE = "offline"  # reported by Tesla, vehicle offline, wake/sleep unknown
+STATUS_UNAVAILABLE = "unavailable"  # set by Controller after successive api failures, overrides the above
+STATUS_UNKNOWN = "unknown"  # set by Controller during initialization, default value

--- a/tests/unit_tests/test_polling_interval.py
+++ b/tests/unit_tests/test_polling_interval.py
@@ -1,7 +1,7 @@
 """Test online sensor."""
 
+from teslajsonpy.const import STATUS_ONLINE, UPDATE_INTERVAL
 from teslajsonpy.controller import Controller
-from teslajsonpy.const import UPDATE_INTERVAL
 from tests.tesla_mock import TeslaMock, VIN, CAR_ID
 
 VIN_INTERVAL = 5
@@ -16,7 +16,7 @@ def test_update_interval(monkeypatch):
     TeslaMock(monkeypatch)
     _controller = Controller(None)
 
-    monkeypatch.setitem(_controller.car_online, VIN, True)
+    _controller._set_car_state(STATUS_ONLINE, vin=VIN)
 
     _controller.set_id_vin(CAR_ID, VIN)
 
@@ -35,7 +35,7 @@ def test_set_update_interval_vin(monkeypatch):
     TeslaMock(monkeypatch)
     _controller = Controller(None)
 
-    monkeypatch.setitem(_controller.car_online, VIN, True)
+    _controller._set_car_state(STATUS_ONLINE, vin=VIN)
 
     _controller.set_id_vin(CAR_ID, VIN)
     _controller.set_id_vin(CAR_ID2, VIN2)
@@ -65,7 +65,7 @@ def test_get_update_interval_vin(monkeypatch):
     TeslaMock(monkeypatch)
     _controller = Controller(None)
 
-    monkeypatch.setitem(_controller.car_online, VIN, True)
+    _controller._set_car_state(STATUS_ONLINE, vin=VIN)
 
     _controller.set_id_vin(CAR_ID, VIN)
     _controller.update_interval = UPDATE_INTERVAL


### PR DESCRIPTION
This refactors how vehicle states are handled in `Controller` by tracking the state string itself, and using helper methods to reflect if car is online or asleep.

### States

Importantly, this changes the behavior of the Online binary_sensor in HA to reflect if the car is available. Since the car remains available when asleep (possible to wake it), and the Online sensor in HA implies that the device is available, this change should reduce confusion about the online state (https://github.com/alandtse/tesla/issues/389, https://github.com/alandtse/tesla/discussions/387).

Additionally, this adds a `car.is_asleep` property which will more accurately reflect if the car is asleep, as it will remember if it's asleep even if the car is temporarily unavailable due to a signal loss or server outage. A small update to the HA integration will be needed to start using this new property.

This also fixes a related issue that the Online sensor would flicker for any transient api request failure. It is common for me to find the Online sensor is often flapping between disconnected and connected, however the reported state from the vehicle list API shows that it was online the entire time.

(flapping of the online sensor due to transient api request failures)
![image](https://user-images.githubusercontent.com/54586926/205468026-729d33a0-6f91-425b-8048-154a752da75a.png)

(compared to actual api state recorded separately)
![image](https://user-images.githubusercontent.com/54586926/205468477-97147d99-2752-47e6-899a-d8ba61bb8834.png)

Now, the online sensor and state attribute will reflect that of Tesla api except when:
- Tesla api is reporting state is online
- and there have been 5 or more consecutive Tesla Exceptions for the vehicle
...in which case the state will show `unavailable` and Online sensor will be false until the next api request for that vehicle succeeds.

### Wake if asleep

The wake_up decorator was removed as it was only used for the `api()` method. The `wake_if_asleep` logic has been refactored between the `Controller.wake_up` and `Controller.api` methods and made to be more readable and handle edge cases better:
- If api is called for a endpoint that does not accept a vehicle_id, and `wake_if_asleep=True`, it will raise an exception
  - with the decorator, it would have failed as it's not possible to wake a vehicle without it'd ID, but also it's not needed to wake a vehicle for these types of commands
- If the api is called with `wake_if_asleep=True` and the car has gone to sleep so recently that the Controller doesn't know it yet, the initial api request will fail, but now it will handle that gracefully, wake the vehicle, and try the command again
  - it appeared the decorator was supposed to do this, but due to some misplaced conditions, it did not.

It's also more efficient by only retrying the wake command if it failed, otherwise it waits for it to come online by polling the VEHICLE_SUMMARY endpoint at regular intervals with it's own timeout.

### Tests

- Added unit tests to ensure the state and online/asleep properties updated as expected
- Tested in a HA dev container with my car, update interval set to 15 seconds, and ensured that the integration allowed the car to sleep once I turned off sentry mode.
- Ensured that the sensors updated as expected to reflect my actual car state
- Ensured that installing the integration did wake up the car even though it was asleep
- Ensured reloading the integration did not wake up the car from sleep
- Ensured no new warnings or errors in HA logs.
- Ensured that sending a pointless command to the car while it's asleep doesn't wake it (such as climate off)
- Ensured that state correctly shows `offline` when vehicle is actually offline