### PR TITLE
fix: Valet mode optional argument

### DIFF
--- a/teslajsonpy/car.py
+++ b/teslajsonpy/car.py
@@ -1029,15 +1029,29 @@ class TeslaCar:
             }
             self._vehicle_data["vehicle_state"].update(params)
 
-    async def valet_mode(self, enable, pin) -> None:
-        """Set Valet Mode."""
-        data = await self._send_command(
-            "SET_VALET_MODE",
-            path_vars={"vehicle_id": self.id},
-            on=enable,
-            pin=pin,
-            wake_if_asleep=True,
-        )
+    async def valet_mode(self, enable, pin=None) -> None:
+        """Set Valet Mode.
+
+        Args
+            enable: True to activate, False to deactivate.
+            pin: optional, not required to activate or deactivate valet mode. Even with a previous PIN set. If you clear the PIN and activate Valet Mode without the parameter, you will only be able to deactivate it from your car's screen by signing into your Tesla account.
+
+        """
+        if pin:
+            data = await self._send_command(
+                "SET_VALET_MODE",
+                path_vars={"vehicle_id": self.id},
+                on=enable,
+                pin=pin,
+                wake_if_asleep=True,
+            )
+        else:
+            data = await self._send_command(
+                "SET_VALET_MODE",
+                path_vars={"vehicle_id": self.id},
+                on=enable,
+                wake_if_asleep=True,
+            )
 
         if data and data["response"]:
             _LOGGER.debug("Valet mode response: %s", data["response"])

--- a/teslajsonpy/car.py
+++ b/teslajsonpy/car.py
@@ -1032,9 +1032,9 @@ class TeslaCar:
     async def valet_mode(self, enable, pin) -> None:
         """Set Valet Mode."""
         data = await self._send_command(
-            "VALET_MODE",
+            "SET_VALET_MODE",
             path_vars={"vehicle_id": self.id},
-            enable=enable,
+            on=enable,
             pin=pin,
             wake_if_asleep=True,
         )

--- a/tests/unit_tests/test_car.py
+++ b/tests/unit_tests/test_car.py
@@ -543,3 +543,5 @@ async def test_valet_mode(monkeypatch):
 
     assert await _car.valet_mode(True, "0000") is None
     assert await _car.valet_mode(False, "0000") is None
+    assert await _car.valet_mode(True) is None
+    assert await _car.valet_mode(False) is None

--- a/tests/unit_tests/test_car.py
+++ b/tests/unit_tests/test_car.py
@@ -249,6 +249,8 @@ async def test_car_properties(monkeypatch):
 
     assert _car.window_rp == VEHICLE_DATA["vehicle_state"]["rp_window"]
 
+    assert _car.is_valet_mode == VEHICLE_DATA["vehicle_state"]["valet_mode"]
+
 
 @pytest.mark.asyncio
 async def test_change_charge_limit(monkeypatch):

--- a/tests/unit_tests/test_car.py
+++ b/tests/unit_tests/test_car.py
@@ -38,7 +38,10 @@ async def test_car_properties(monkeypatch):
 
     assert _car.battery_level == VEHICLE_DATA["charge_state"]["battery_level"]
 
-    assert _car.usable_battery_level == VEHICLE_DATA["charge_state"]["usable_battery_level"]
+    assert (
+        _car.usable_battery_level
+        == VEHICLE_DATA["charge_state"]["usable_battery_level"]
+    )
 
     assert _car.battery_range == VEHICLE_DATA["charge_state"]["battery_range"]
 
@@ -226,9 +229,9 @@ async def test_car_properties(monkeypatch):
 
     assert _car.software_update == VEHICLE_DATA["vehicle_state"]["software_update"]
 
-    assert _car.steering_wheel_heater == (VEHICLE_DATA["climate_state"].get(
-        "steering_wheel_heater"
-    ) is not None)
+    assert _car.steering_wheel_heater == (
+        VEHICLE_DATA["climate_state"].get("steering_wheel_heater") is not None
+    )
 
     assert _car.third_row_seats == str(
         VEHICLE_DATA["vehicle_state"].get("third_row_seats")
@@ -525,3 +528,16 @@ async def test_close_windows(monkeypatch):
     _car = _controller.cars[VIN]
 
     assert await _car.close_windows() is None
+
+
+@pytest.mark.asyncio
+async def test_valet_mode(monkeypatch):
+    """Test close windows."""
+    TeslaMock(monkeypatch)
+    _controller = Controller(None)
+    await _controller.connect()
+    await _controller.generate_car_objects()
+    _car = _controller.cars[VIN]
+
+    assert await _car.valet_mode(True, "0000") is None
+    assert await _car.valet_mode(False, "0000") is None

--- a/tests/unit_tests/test_car.py
+++ b/tests/unit_tests/test_car.py
@@ -584,21 +584,6 @@ async def test_valet_mode(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_valet_mode(monkeypatch):
-    """Test close windows."""
-    TeslaMock(monkeypatch)
-    _controller = Controller(None)
-    await _controller.connect()
-    await _controller.generate_car_objects()
-    _car = _controller.cars[VIN]
-
-    assert await _car.valet_mode(True, "0000") is None
-    assert await _car.valet_mode(False, "0000") is None
-    assert await _car.valet_mode(True) is None
-    assert await _car.valet_mode(False) is None
-
-
-@pytest.mark.asyncio
 async def test_remote_start(monkeypatch):
     """Test remote start."""
     TeslaMock(monkeypatch)


### PR DESCRIPTION
I missed this paragraph about the valet mode command in [Tesla JSON API](https://tesla-api.timdorr.com/vehicle/commands/valet#post-api-1-vehicles-id-command-set_valet_mode).

```
Note: the password parameter isn't required to turn on or off Valet Mode, even with a previous PIN set. If you clear the PIN and activate Valet Mode without the parameter, you will only be able to deactivate it from your car's screen by signing into your Tesla account.
```

Turning valet mode on and off from the app does not require the pin. That argument is useful for setting a cleared pin. Not useful if the pin is already set.