### PR TITLE
fix: valet mode parameter name wrong

### DIFF
--- a/teslajsonpy/car.py
+++ b/teslajsonpy/car.py
@@ -1073,7 +1073,7 @@ class TeslaCar:
 
         Args
             enable: True to activate, False to deactivate.
-            password: optional, pin not required to activate or deactivate valet mode. Even with a previous PIN set. If you clear the PIN and activate Valet Mode without the parameter, you will only be able to deactivate it from your car's screen by signing into your Tesla account.
+            pin: optional, pin not required to activate or deactivate valet mode. Even with a previous PIN set. If you clear the PIN and activate Valet Mode without the parameter, you will only be able to deactivate it from your car's screen by signing into your Tesla account.
 
         """
         if pin:

--- a/teslajsonpy/car.py
+++ b/teslajsonpy/car.py
@@ -1073,7 +1073,7 @@ class TeslaCar:
 
         Args
             enable: True to activate, False to deactivate.
-            pin: optional, not required to activate or deactivate valet mode. Even with a previous PIN set. If you clear the PIN and activate Valet Mode without the parameter, you will only be able to deactivate it from your car's screen by signing into your Tesla account.
+            password: optional, pin not required to activate or deactivate valet mode. Even with a previous PIN set. If you clear the PIN and activate Valet Mode without the parameter, you will only be able to deactivate it from your car's screen by signing into your Tesla account.
 
         """
         if pin:
@@ -1081,7 +1081,7 @@ class TeslaCar:
                 "SET_VALET_MODE",
                 path_vars={"vehicle_id": self.id},
                 on=enable,
-                pin=pin,
+                password=pin,
                 wake_if_asleep=True,
             )
         else:


### PR DESCRIPTION
Sorry I missed this, the correct key was 'password' not 'pin'.

https://tesla-api.timdorr.com/vehicle/commands/valet#post-api-1-vehicles-id-command-set_valet_mode