### PR TITLE
feat: include TeslaExceptions for api retries

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -145,14 +145,6 @@ python-versions = ">=3.6"
 pytz = ">=2015.7"
 
 [[package]]
-name = "backoff"
-version = "2.2.1"
-description = "Function decoration for backoff and retry"
-category = "main"
-optional = false
-python-versions = ">=3.7,<4.0"
-
-[[package]]
 name = "beautifulsoup4"
 version = "4.11.1"
 description = "Screen-scraping library"
@@ -922,6 +914,17 @@ lint = ["docutils-stubs", "flake8", "mypy"]
 test = ["pytest"]
 
 [[package]]
+name = "tenacity"
+version = "8.1.0"
+description = "Retry code until it succeeds"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+doc = ["reno", "sphinx", "tornado (>=4.5)"]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -1060,7 +1063,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "3dd606e16b92391188ccfe2345783d1d0201e33175abf25980e6913cc8959906"
+content-hash = "5a96be5d314accea89d575aec30127b5163120186032bb02c3c8b399f5dc7258"
 
 [metadata.files]
 aiohttp = [
@@ -1190,10 +1193,6 @@ autoapi = [
 babel = [
     {file = "Babel-2.10.3-py3-none-any.whl", hash = "sha256:ff56f4892c1c4bf0d814575ea23471c230d544203c7748e8c68f0089478d48eb"},
     {file = "Babel-2.10.3.tar.gz", hash = "sha256:7614553711ee97490f732126dc077f8d0ae084ebc6a96e23db1482afabdb2c51"},
-]
-backoff = [
-    {file = "backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8"},
-    {file = "backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba"},
 ]
 beautifulsoup4 = [
     {file = "beautifulsoup4-4.11.1-py3-none-any.whl", hash = "sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30"},
@@ -1760,6 +1759,10 @@ sphinxcontrib-qthelp = [
 sphinxcontrib-serializinghtml = [
     {file = "sphinxcontrib-serializinghtml-1.1.5.tar.gz", hash = "sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952"},
     {file = "sphinxcontrib_serializinghtml-1.1.5-py2.py3-none-any.whl", hash = "sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd"},
+]
+tenacity = [
+    {file = "tenacity-8.1.0-py3-none-any.whl", hash = "sha256:35525cd47f82830069f0d6b73f7eb83bc5b73ee2fff0437952cedf98b27653ac"},
+    {file = "tenacity-8.1.0.tar.gz", hash = "sha256:e48c437fdf9340f5666b92cd7990e96bc5fc955e1298baf4a907e3972067a445"},
 ]
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ include = [
 [tool.poetry.dependencies]
 python = "^3.7"
 aiohttp = ">=3.7.4"
-backoff = ">=1.10.0"
+tenacity = ">=8.1.0"
 beautifulsoup4 = ">=4.9.3"
 wrapt = ">=1.12.1"
 authcaptureproxy = ">=1.1.3"

--- a/teslajsonpy/const.py
+++ b/teslajsonpy/const.py
@@ -13,6 +13,7 @@ UPDATE_INTERVAL = 300  # Default polling interval for vehicle
 WEBSOCKET_TIMEOUT = 11  # time for websocket to timeout
 WAKE_TIMEOUT = 60  # max time to wait for vehicle to wake
 WAKE_CHECK_INTERVAL = 2  # wait period between wake checks after a wake request
+MAX_API_RETRY_TIME = 15  # how long to retry api calls
 RELEASE_NOTES_URL = "https://teslascope.com/teslapedia/software/"
 AUTH_DOMAIN = "https://auth.tesla.com"
 API_URL = "https://owner-api.teslamotors.com"

--- a/teslajsonpy/exceptions.py
+++ b/teslajsonpy/exceptions.py
@@ -6,7 +6,13 @@ For more details about this api, please refer to the documentation at
 https://github.com/zabuldon/teslajsonpy
 """
 import logging
+import random
 from typing import Any, Dict, Text
+
+from httpx import RequestError
+from tenacity import RetryCallState
+
+from teslajsonpy.const import MAX_API_RETRY_TIME
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,6 +49,11 @@ class TeslaException(Exception):
         elif self.code > 299:
             self.message = f"UNKNOWN_ERROR_{self.code}"
 
+    @property
+    def retryable(self):
+        """Determine if this exception can/should be retried."""
+        return self.code not in [401, 404, 405, 423, 429]
+
 
 class RetryLimitError(TeslaException):
     """Class of exceptions for hitting retry limits."""
@@ -71,27 +82,42 @@ class HomelinkError(TeslaException):
     pass
 
 
-def should_giveup(ex: Exception) -> bool:
-    """Test whether the exception should result in a retry.
-
-    This is consumed by backoff.
+def custom_retry(retry_state: RetryCallState) -> bool:
+    """Determine whether Tenacity should retry.
 
     Args
-        ex (Exception): The exception
+        retry_state (RetryCallState): Provided by Tenacity
 
     Returns
-        bool: whether backoff should give up
+        bool: whether or not to retry
 
     """
+    if not retry_state.outcome.failed:
+        return False
+
+    ex = retry_state.outcome.exception()
     return (
-        isinstance(ex, (IncompleteCredentials, RetryLimitError))
-        or not hasattr(ex, "code")
-        or ex.code
-        in [
-            401,
-            404,
-            405,
-            423,
-            429,
-        ]
+        isinstance(ex, RequestError) or isinstance(ex, TeslaException) and ex.retryable
     )
+
+
+def custom_wait(retry_state: RetryCallState) -> float:
+    """Determine how long to wait before retrying.
+
+    Args
+        retry_state (RetryCallState): Provided by Tenacity
+
+    Returns
+        float: time to wait in seconds
+
+    """
+    initial = 1
+    base = 2
+    jitter = random.uniform(0, 1)
+    max_wait = MAX_API_RETRY_TIME - retry_state.seconds_since_start
+    try:
+        exp = base ** (retry_state.attempt_number - 1)
+        result = initial * exp + jitter
+    except OverflowError:
+        result = max_wait
+    return max(0, min(result, max_wait))

--- a/tests/unit_tests/test_exceptions.py
+++ b/tests/unit_tests/test_exceptions.py
@@ -1,0 +1,67 @@
+"""Test exception retry logic."""
+
+from httpx import RequestError
+from tenacity import RetryCallState, Retrying
+
+from teslajsonpy.const import MAX_API_RETRY_TIME
+from teslajsonpy.exceptions import custom_retry, custom_wait, TeslaException
+
+
+def test_tesla_exception_retryable():
+    # code, retryable
+    test_set = [
+        (408, True),
+        (540, True),
+        (401, False),
+        (404, False),
+        (405, False),
+        (423, False),
+        (429, False),
+    ]
+
+    for code, expected in test_set:
+        exc = TeslaException(code)
+        assert exc.retryable == expected
+
+
+def test_custom_retry():
+    # No exceptions means we don't retry
+    rs = RetryCallState(Retrying(), None, None, None)
+    rs.set_result(None)
+    assert custom_retry(rs) is False
+
+    # Add a retryable exception
+    ex = TeslaException(408)
+    rs.set_exception((type(ex), ex, None))
+    assert custom_retry(rs) is True
+
+    # Add a non-retryable exception
+    ex = TeslaException(401)
+    rs.set_exception((type(ex), ex, None))
+    assert custom_retry(rs) is False
+
+    # Any RequestError should also retry
+    ex = RequestError("")
+    rs.set_exception((type(ex), ex, None))
+    assert custom_retry(rs) is True
+
+
+def test_custom_wait():
+    rs = RetryCallState(Retrying(), None, None, None)
+    # sec_since_start, attempt, wait_min, wait_max
+    test_set = [
+        (0, 1, 1, 2),
+        (0, 2, 2, 3),
+        (0, 3, 4, 5),
+        (0, 4, 8, 9),
+        (0, 5, 15, 15),
+        (14, 2, 1, 1),
+        (16, 1, 0, 0),
+    ]
+    assert MAX_API_RETRY_TIME == 15
+    for sec, attempt, expected_min, expected_max in test_set:
+        rs.outcome_timestamp = rs.start_time + sec
+        rs.attempt_number = attempt
+        wait = custom_wait(rs)
+        assert wait >= expected_min
+        assert wait <= expected_max


### PR DESCRIPTION
To combat transient api exceptions such as 408 when the vehicle has limited connectivity, the retry logic has been updated to handle `TeslaException` as well the existing `httpx.RequestError`

- multiple existing retry decorators for `httpx.RequestError` were refactored to a single `__post_with_retries` method since they all had the same parameters anyway
- `__post_with_retries` method added to decorate the api post as late as possible in the chain to prevent more high level logic from getting caught up in retries (such as the wake up logic), and ensuring the retries are as fast as possible
- `backoff` library replaced by `tenacity` library to give more flexibility in the retry logic, as well as to avoid some known timing bugs that `backoff` had.
- refactors the giveup logic into a `TeslaException.retryable` property for easier re-use

Note that a 15 second max timeout is used to ensure there is plenty of buffer between the last attempt and the 30 second HA core timeout for the component to finish updating. Cars with poor connectivity often fail for a 408 with a timeout response, these failures eat up ~10 seconds for each attempt, so using a max retry window of 15 seconds means we shouldn't exceed much more than 25 seconds for a complete update request. 

Tested in dev HA container with a model 3 and additional logging:
- with the car asleep, sent an api command that does not try to wake (climate off)
- ensured that tenacity was retrying the command when encountering 408
- ensured the retry waits were increasing exponentially
- ensured that tenacity gives up after `MAX_API_RETRY_TIME` and raises the exception to the caller
- with the car asleep, sent an api command which uses wake_if_asleep (climate on)
- ensured that tenacity did not interfere with the wakeup logic, no retries were needed or performed