### PR TITLE
fix: Replace charge_amps with charge_current_request in set_charging_amps

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -19,3 +19,4 @@
 -   carleeno [Github](https://github.com/carleeno)
 -   shred [Github](https://github.com/shred86)
 -   InTheDaylight14 [Github](https://github.com/InTheDaylight14)
+-   Bre77 [Github](https://github.com/Bre77)

--- a/teslajsonpy/car.py
+++ b/teslajsonpy/car.py
@@ -897,7 +897,10 @@ class TeslaCar:
             )
 
         if data and data["response"]["result"] is True:
-            params = {"charge_current_request": int(value)}
+            params = {
+                "charge_amps": int(value),
+                "charge_current_request": int(value),
+            }
             self._vehicle_data["charge_state"].update(params)
 
     async def set_cabin_overheat_protection(self, option: str) -> None:

--- a/tests/unit_tests/test_car.py
+++ b/tests/unit_tests/test_car.py
@@ -454,8 +454,8 @@ async def test_set_charging_amps(monkeypatch):
     await _controller.generate_car_objects()
     _car = _controller.cars[VIN]
 
-    assert await _car.set_charging_amps(32.0) is None
-    assert _car.charge_current_request == 32.0
+    assert await _car.set_charging_amps(16.0) is None
+    assert _car.charge_current_request == 16.0
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_car.py
+++ b/tests/unit_tests/test_car.py
@@ -455,6 +455,7 @@ async def test_set_charging_amps(monkeypatch):
     _car = _controller.cars[VIN]
 
     assert await _car.set_charging_amps(32.0) is None
+    assert _car.charge_current_request == 32.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
When calling `set_charging_amps` it looks for a parameter `charge_amps` and uses this to save the updated value, however this parameter isnt used anywhere else. I believe this is actually meant to be the `charge_current_request` parameter.

Fixes https://github.com/alandtse/tesla/issues/479