### PR TITLE
fix: don't assume climate_state exists

### DIFF
--- a/teslajsonpy/car.py
+++ b/teslajsonpy/car.py
@@ -874,7 +874,7 @@ class TeslaCar:
         """Return status of seat heater for a given seat."""
         seat_id = f"seat_heater_{SEAT_ID_MAP[seat_id]}"
         if self.data_available:
-            return self._vehicle_data.get("climate_state").get(seat_id)
+            return self._vehicle_data.get("climate_state", {}).get(seat_id)
         return None
 
     async def schedule_software_update(self, offset_sec: Optional[int] = 0) -> None:

--- a/tests/unit_tests/test_car.py
+++ b/tests/unit_tests/test_car.py
@@ -749,3 +749,15 @@ async def test_remote_boombox(monkeypatch):
     _car = _controller.cars[VIN]
 
     assert await _car.remote_boombox() is None
+
+@pytest.mark.asyncio
+async def test_get_seat_heater_status(monkeypatch):
+    """Test get seat heater status."""
+    TeslaMock(monkeypatch)
+    _controller = Controller(None)
+    await _controller.connect()
+    await _controller.generate_car_objects()
+    _car = _controller.cars[VIN]
+
+    assert _car.get_seat_heater_status(1) is 0
+    assert _car.get_seat_heater_status(7) is None

--- a/tests/unit_tests/test_car.py
+++ b/tests/unit_tests/test_car.py
@@ -761,3 +761,11 @@ async def test_get_seat_heater_status(monkeypatch):
 
     assert _car.get_seat_heater_status(1) is 0
     assert _car.get_seat_heater_status(7) is None
+
+    orig_climate_state = _car._vehicle_data["climate_state"]
+    del _car._vehicle_data["climate_state"]
+
+    assert _car.get_seat_heater_status(1) is None
+
+    # Restoring state incase its used later
+    _car._vehicle_data["climate_state"] = orig_climate_state


### PR DESCRIPTION
Home Assistant sometimes throws the following error on startup

```
Traceback (most recent call last):
  File "/config/custom_components/tesla_custom/teslamate.py", line 208, in msg_recieved
    ).result()
  File "/usr/local/python/lib/python3.10/concurrent/futures/_base.py", line 446, in result
    return self.__get_result()
  File "/usr/local/python/lib/python3.10/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
  File "/config/custom_components/tesla_custom/teslamate.py", line 237, in async_handle_new_data
    coordinator.async_update_listeners()
  File "/usr/local/python/lib/python3.10/site-packages/homeassistant/helpers/update_coordinator.py", line 135, in async_update_listeners
    update_callback()
  File "/config/custom_components/tesla_custom/base.py", line 40, in refresh
    self.async_write_ha_state()
  File "/usr/local/python/lib/python3.10/site-packages/homeassistant/helpers/entity.py", line 559, in async_write_ha_state
    self._async_write_ha_state()
  File "/usr/local/python/lib/python3.10/site-packages/homeassistant/helpers/entity.py", line 600, in _async_write_ha_state
    state = self._stringify_state(available)
  File "/usr/local/python/lib/python3.10/site-packages/homeassistant/helpers/entity.py", line 565, in _stringify_state
    if (state := self.state) is None:
  File "/usr/local/python/lib/python3.10/site-packages/homeassistant/components/select/__init__.py", line 147, in state
    if self.current_option is None or self.current_option not in self.options:
  File "/config/custom_components/tesla_custom/select.py", line 156, in current_option
    current_value = self._car.get_seat_heater_status(
  File "/usr/local/python/lib/python3.10/site-packages/teslajsonpy/car.py", line 879, in get_seat_heater_status
    return self._vehicle_data.get("climate_state").get(seat_id)
AttributeError: 'NoneType' object has no attribute 'get'
```

This is because get_seat_heater_status doesn't return an empty dict if climate_state doesn't exist.

This fixes that error. All other calls in `car.py` return an empty dict instead of None