### PR TITLE
fix: avoid retry on sleep/unavailable when the car is asleep with wake_if_asleep=False

### DIFF
--- a/teslajsonpy/car.py
+++ b/teslajsonpy/car.py
@@ -987,8 +987,7 @@ class TeslaCar:
         """
 
         data = await self._send_command(
-            "REMOTE_AUTO_STEERING_WHEEL_HEAT_CLIMATE_REQUEST",
-            on=enable
+            "REMOTE_AUTO_STEERING_WHEEL_HEAT_CLIMATE_REQUEST", on=enable
         )
         if data and data["response"]["result"] is True:
             params = {"auto_steering_wheel_heat": enable}
@@ -1017,7 +1016,9 @@ class TeslaCar:
     def get_heated_steering_wheel_level(self) -> int:
         """Return the status of the heated steering wheel."""
         if self.data_available:
-            return self._vehicle_data.get("climate_state", {}).get("steering_wheel_heat_level")
+            return self._vehicle_data.get("climate_state", {}).get(
+                "steering_wheel_heat_level"
+            )
         return None
 
     async def set_hvac_mode(self, value: str) -> None:

--- a/teslajsonpy/exceptions.py
+++ b/teslajsonpy/exceptions.py
@@ -82,6 +82,25 @@ class HomelinkError(TeslaException):
     pass
 
 
+def custom_retry_except_unavailable(retry_state: RetryCallState) -> bool:
+    """Determine whether Tenacity should retry.
+
+    Args
+        retry_state (RetryCallState): Provided by Tenacity
+
+    Returns
+        bool: whether or not to retry
+
+    """
+    if not custom_retry(retry_state):
+        return False
+    ex = retry_state.outcome.exception()
+    if isinstance(ex, TeslaException):
+        if ex.code == 408:  # "VEHICLE_UNAVAILABLE"
+            return False
+    return True
+
+
 def custom_retry(retry_state: RetryCallState) -> bool:
     """Determine whether Tenacity should retry.
 


### PR DESCRIPTION
We would retry on 408s even if wake_if_asleep was False which slowed down startup a lot for cars we did not wake

Before: startup 145.3s
After: startup 15.2s