### PR TITLE
fix: Supply 'endpoints' parameter to vehicle_data endpoint

### DIFF
--- a/teslajsonpy/endpoints.json
+++ b/teslajsonpy/endpoints.json
@@ -31,7 +31,7 @@
   },
   "VEHICLE_DATA": {
     "TYPE": "GET",
-    "URI": "api/1/vehicles/{vehicle_id}/vehicle_data",
+    "URI": "api/1/vehicles/{vehicle_id}/vehicle_data?endpoints=charge_state;climate_state;drive_state;gui_settings;vehicle_config;vehicle_state;location_data",
     "AUTH": true
   },
   "VEHICLE_SERVICE_DATA": {
@@ -502,7 +502,7 @@
     "AUTH": true,
     "TYPE": "GET",
     "URI": "api/1/energy_sites/{site_id}/site_status"
-  },  
+  },
   "OPERATION_MODE": {
     "TYPE": "POST",
     "URI": "api/1/energy_sites/{site_id}/operation",
@@ -2767,5 +2767,5 @@
     "AUTH": true,
     "TYPE": "POST",
     "URI": "api/1/energy_sites/{site_id}/operation"
-  }  
+  }
 }


### PR DESCRIPTION
After upgrading to 2023.38.* the Tesla API requires specifying the query parameter `endpoints` when asking for location data from the vehicle. Supply this parameter along with other parameters needed to fetch the vehicle data.

I didn't really test this properly except via the home assistant plugin, so more testing may be needed.

This change corresponds to the changes in `teslamate` and `TeslaPy`:
https://github.com/tdorssers/TeslaPy/commit/38ff7da6e5a7aa1fcd5d39b84aa1d89c9cff50b5
https://github.com/adriankumpf/teslamate/commit/5058a6fa07f3fae2f1552c7150b28481446967c5

API Documentation:
https://developer.tesla.com/docs/fleet-api#vehicle_data

Fixes #434