### PR TITLE
fix: escape semicolons in vehicle_data endpoint

### DIFF
--- a/teslajsonpy/endpoints.json
+++ b/teslajsonpy/endpoints.json
@@ -31,7 +31,7 @@
   },
   "VEHICLE_DATA": {
     "TYPE": "GET",
-    "URI": "api/1/vehicles/{vehicle_id}/vehicle_data?endpoints=charge_state;climate_state;drive_state;gui_settings;vehicle_config;vehicle_state;location_data",
+    "URI": "api/1/vehicles/{vehicle_id}/vehicle_data?endpoints=charge_state%3Bclimate_state%3Bdrive_state%3Bgui_settings%3Bvehicle_config%3Bvehicle_state%3Blocation_data",
     "AUTH": true
   },
   "VEHICLE_SERVICE_DATA": {


### PR DESCRIPTION
For some reason, the Tesla API sometimes do not return all the data unless the semicolons in the endpoints parameter are URL encoded.

Replace ; with %3B which is the URL encoded value.