### PR TITLE
style: fix whitespace and formatting

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -213,13 +213,13 @@ files = [
 
 [[package]]
 name = "attrs"
-version = "23.1.0"
+version = "23.2.0"
 description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "attrs-23.1.0-py3-none-any.whl", hash = "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04"},
-    {file = "attrs-23.1.0.tar.gz", hash = "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"},
+    {file = "attrs-23.2.0-py3-none-any.whl", hash = "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"},
+    {file = "attrs-23.2.0.tar.gz", hash = "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30"},
 ]
 
 [package.dependencies]
@@ -227,10 +227,11 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 cov = ["attrs[tests]", "coverage[toml] (>=5.3)"]
-dev = ["attrs[docs,tests]", "pre-commit"]
+dev = ["attrs[tests]", "pre-commit"]
 docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope-interface"]
 tests = ["attrs[tests-no-zope]", "zope-interface"]
-tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=1.1.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
+tests-mypy = ["mypy (>=1.6)", "pytest-mypy-plugins"]
+tests-no-zope = ["attrs[tests-mypy]", "cloudpickle", "hypothesis", "pympler", "pytest (>=4.3.0)", "pytest-xdist[psutil]"]
 
 [[package]]
 name = "authcaptureproxy"
@@ -267,18 +268,17 @@ sphinx = "*"
 
 [[package]]
 name = "babel"
-version = "2.13.1"
+version = "2.14.0"
 description = "Internationalization utilities"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Babel-2.13.1-py3-none-any.whl", hash = "sha256:7077a4984b02b6727ac10f1f7294484f737443d7e2e66c5e4380e41a3ae0b4ed"},
-    {file = "Babel-2.13.1.tar.gz", hash = "sha256:33e0952d7dd6374af8dbf6768cc4ddf3ccfefc244f9986d4074704f2fbd18900"},
+    {file = "Babel-2.14.0-py3-none-any.whl", hash = "sha256:efb1a25b7118e67ce3a259bed20545c29cb68be8ad2c784c83689981b7a57287"},
+    {file = "Babel-2.14.0.tar.gz", hash = "sha256:6919867db036398ba21eb5c7a0f6b28ab8cbc3ae7a73a44ebe34ae74a4e7d363"},
 ]
 
 [package.dependencies]
 pytz = {version = ">=2015.7", markers = "python_version < \"3.9\""}
-setuptools = {version = "*", markers = "python_version >= \"3.12\""}
 
 [package.extras]
 dev = ["freezegun (>=1.0,<2.0)", "pytest (>=6.0)", "pytest-cov"]
@@ -600,13 +600,13 @@ graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
 name = "distlib"
-version = "0.3.7"
+version = "0.3.8"
 description = "Distribution utilities"
 optional = false
 python-versions = "*"
 files = [
-    {file = "distlib-0.3.7-py2.py3-none-any.whl", hash = "sha256:2e24928bc811348f0feb63014e97aaae3037f2cf48712d51ae61df7fd6075057"},
-    {file = "distlib-0.3.7.tar.gz", hash = "sha256:9dafe54b34a028eafd95039d5e5d4851a13734540f1331060d31c9916e7147a8"},
+    {file = "distlib-0.3.8-py2.py3-none-any.whl", hash = "sha256:034db59a0b96f8ca18035f36290806a9a6e6bd9d1ff91e45a7f172eb17e51784"},
+    {file = "distlib-0.3.8.tar.gz", hash = "sha256:1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64"},
 ]
 
 [[package]]
@@ -1412,13 +1412,13 @@ testing = ["covdefaults (>=2.3)", "importlib-metadata (>=6.6)", "pytest (>=7.3.1
 
 [[package]]
 name = "pytest"
-version = "7.4.3"
+version = "7.4.4"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.4.3-py3-none-any.whl", hash = "sha256:0d009c083ea859a71b76adf7c1d502e4bc170b80a8ef002da5806527b9591fac"},
-    {file = "pytest-7.4.3.tar.gz", hash = "sha256:d989d136982de4e3b29dabcc838ad581c64e8ed52c11fbe86ddebd9da0818cd5"},
+    {file = "pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"},
+    {file = "pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280"},
 ]
 
 [package.dependencies]
@@ -1563,19 +1563,19 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "setuptools"
-version = "69.0.2"
+version = "68.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.7"
 files = [
-    {file = "setuptools-69.0.2-py3-none-any.whl", hash = "sha256:1e8fdff6797d3865f37397be788a4e3cba233608e9b509382a2777d25ebde7f2"},
-    {file = "setuptools-69.0.2.tar.gz", hash = "sha256:735896e78a4742605974de002ac60562d286fa8051a7e2299445e8e8fbb01aa6"},
+    {file = "setuptools-68.0.0-py3-none-any.whl", hash = "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f"},
+    {file = "setuptools-68.0.0.tar.gz", hash = "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "sniffio"

--- a/teslajsonpy/controller.py
+++ b/teslajsonpy/controller.py
@@ -339,12 +339,12 @@ class Controller:
         return (await self.api("SITE_DATA", path_vars={"site_id": energysite_id}))[
             "response"
         ]
-        
+
     async def get_site_summary(self, energysite_id: int) -> dict:
         """Get site data json from TeslaAPI for a given energysite_id."""
         return (await self.api("SITE_SUMMARY", path_vars={"site_id": energysite_id}))[
             "response"
-        ]    
+        ]
 
     async def generate_car_objects(
         self,
@@ -412,7 +412,7 @@ class Controller:
                     ex.message,
                 )
                 self._site_data[energysite_id] = {}
-            
+
             if energysite[RESOURCE_TYPE] == RESOURCE_TYPE_SOLAR:
 
                 self.energysites[energysite_id] = SolarSite(
@@ -422,11 +422,11 @@ class Controller:
                     self._site_data[energysite_id],
                 )
             # Powerwall systems listed as "battery"
-            if energysite[RESOURCE_TYPE] == RESOURCE_TYPE_BATTERY:                
-                                    
+            if energysite[RESOURCE_TYPE] == RESOURCE_TYPE_BATTERY:
+
                 self._site_summary[energysite_id] = await self.get_site_summary(
-                        energysite_id
-                    )                    
+                    energysite_id
+                )
 
                 if energysite["components"]["solar"]:
                     self.energysites[energysite_id] = SolarPowerwallSite(
@@ -443,7 +443,7 @@ class Controller:
                         self._site_config[energysite_id],
                         self._site_data[energysite_id],
                         self._site_summary[energysite_id],
-                    )            
+                    )
 
         return self.energysites
 
@@ -694,17 +694,17 @@ class Controller:
                     del response["solar_power"]
 
                 self._site_data[energysite_id].update(response)
-                
+
         async def _get_and_process_site_summary(energysite_id: int) -> None:
             _LOGGER.debug("Updating SITE_SUMMARY for energysite: %s", energysite_id)
             try:
                 response = await self.get_site_summary(energysite_id)
             except TeslaException:
                 response = None
- 
+
             if response:
                 self._site_summary[energysite_id].update(response)
-                
+
         async def _get_and_process_site_config(energysite_id: int) -> None:
             _LOGGER.debug("Updating SITE_CONFIG for energysite: %s", energysite_id)
             try:
@@ -713,7 +713,7 @@ class Controller:
                 response = None
 
             if response:
-                self._site_config[energysite_id].update(response)                
+                self._site_config[energysite_id].update(response)
 
         async with self.__update_lock:
             if self._vehicle_list:
@@ -807,10 +807,10 @@ class Controller:
                         and energysite_id not in energy_site_ids
                     ):
                         continue
-                       
+
                     tasks.append(_get_and_process_site_data(energysite_id))
                     tasks.append(_get_and_process_site_config(energysite_id))
-                    
+
                     if energysite[RESOURCE_TYPE] == RESOURCE_TYPE_BATTERY:
                         tasks.append(_get_and_process_site_summary(energysite_id))
 

--- a/teslajsonpy/energy.py
+++ b/teslajsonpy/energy.py
@@ -122,7 +122,7 @@ class PowerwallSite(EnergySite):
         self,
         api: Callable,
         energysite: dict,
-        site_config: dict,        
+        site_config: dict,
         site_data: dict,
         site_summary: dict,
     ) -> None:
@@ -153,9 +153,8 @@ class PowerwallSite(EnergySite):
 
     @property
     def grid_power(self) -> float:
-        """Return grid power in Watts."""    
+        """Return grid power in Watts."""
         return self._site_data.get("grid_power")
-        
 
     @property
     def grid_status(self) -> str:


### PR DESCRIPTION
The contributing guide advises to run `make lint`. I fixed all existing ones in this separate PR before starting to add my own new errors.

Before:
```
(teslajsonpy-py3.11) ~/src/teslajsonpy (dev ✗) make lint
poetry run flake8 teslajsonpy
teslajsonpy/controller.py:342:1: W293 blank line contains whitespace
teslajsonpy/controller.py:347:10: W291 trailing whitespace
teslajsonpy/controller.py:415:1: W293 blank line contains whitespace
teslajsonpy/controller.py:425:67: W291 trailing whitespace
teslajsonpy/controller.py:426:1: W293 blank line contains whitespace
teslajsonpy/controller.py:428:25: E126 continuation line over-indented for hanging indent
teslajsonpy/controller.py:429:21: E121 continuation line under-indented for hanging indent
teslajsonpy/controller.py:429:22: W291 trailing whitespace
teslajsonpy/controller.py:446:22: W291 trailing whitespace
teslajsonpy/controller.py:697:1: W293 blank line contains whitespace
teslajsonpy/controller.py:704:1: W293 blank line contains whitespace
teslajsonpy/controller.py:707:1: W293 blank line contains whitespace
teslajsonpy/controller.py:716:66: W291 trailing whitespace
teslajsonpy/controller.py:810:1: W293 blank line contains whitespace
teslajsonpy/controller.py:813:1: W293 blank line contains whitespace
teslajsonpy/energy.py:125:27: W291 trailing whitespace
teslajsonpy/energy.py:156:42: W291 trailing whitespace
teslajsonpy/energy.py:158:1: W293 blank line contains whitespace
teslajsonpy/energy.py:160:5: E303 too many blank lines (2)
make: *** [flake8] Error 1
```

After:
```
(teslajsonpy-py3.11) ~/src/teslajsonpy (fix-make-lint ✔) make lint
poetry run flake8 teslajsonpy
poetry run pydocstyle teslajsonpy
poetry run pylint teslajsonpy

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```