### PR TITLE
fix: Remove references to deprecated vehicles endpoint.

### DIFF
--- a/teslajsonpy/endpoints.json
+++ b/teslajsonpy/endpoints.json
@@ -14,11 +14,6 @@
     "URI": "api/1/products",
     "AUTH": true
   },
-  "VEHICLE_LIST": {
-    "TYPE": "GET",
-    "URI": "api/1/vehicles",
-    "AUTH": true
-  },
   "VEHICLE_ORDER_LIST": {
     "TYPE": "GET",
     "URI": "api/1/users/orders",


### PR DESCRIPTION
This should resolve issue #448 for pre-2021 Model X/Model S cars.

Based on the changes described in https://github.com/alandtse/tesla/issues/774#issuecomment-1917821933

It won't necessarily help with newer cars, but should do no harm.

Tested with 2017 MX.