### PR TITLE
feat!: add support for HTTP Proxy

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -25,3 +25,13 @@ If you're looking to add functionality to Home Assistant you will need to do the
 2. Build a proper abstraction inheriting from the [vehicle.py](teslajsonpy/vehicle.py).  Check out [lock.py](teslajsonpy/lock.py).
 3. Add abstraction to the controller [_add_components](https://github.com/zabuldon/teslajsonpy/blob/dev/teslajsonpy/controller.py#L530) so it will be discoverable.
 3. Add changes to Home Assistant to access your abstraction and submit a PR per HA guidelines.
+
+## Experimental support for Tesla HTTP Proxy
+Tesla has deprecated the Owner API for modern vehicles.  
+https://developer.tesla.com/docs/fleet-api#2023-10-09-rest-api-vehicle-commands-endpoint-deprecation-warning  
+To use the HTTP Proxy, you must provide your Client ID and Proxy URL (e.g. https://tesla.example.com).  If your proxy uses a self-signed certificate, you may provide the path to that certificate as a config parameter so it will be trusted.
+The proxy server requires the command URL to contain the VIN, not the ID.  [Reference](https://github.com/teslamotors/vehicle-command).  Otherwise you get an error like this:
+```
+[teslajsonpy.connection] post: https://local-tesla-http-proxy:4430/api/1/vehicles/xxxxxxxxxxxxxxxx/command/auto_conditioning_start {}
+[teslajsonpy.connection] 404: {"response":null,"error":"expected 17-character VIN in path (do not user Fleet API ID)","error_description":""}
+```

--- a/teslajsonpy/car.py
+++ b/teslajsonpy/car.py
@@ -751,7 +751,7 @@ class TeslaCar:
             **kwargs: Any additional parameters for the api call
 
         """
-        path_vars = {"vehicle_id": self.id}
+        path_vars = {"vehicle_id": self.vin}
         if additional_path_vars:
             path_vars.update(additional_path_vars)
 
@@ -1127,7 +1127,7 @@ class TeslaCar:
 
     async def wake_up(self) -> None:
         """Send command to wake up."""
-        await self._controller.wake_up(car_id=self.id)
+        await self._controller.wake_up(car_vin=self.vin)
 
     async def toggle_trunk(self) -> None:
         """Actuate rear trunk."""

--- a/teslajsonpy/connection.py
+++ b/teslajsonpy/connection.py
@@ -25,6 +25,7 @@ from yarl import URL
 
 from teslajsonpy.const import (
     API_URL,
+    CLIENT_ID,
     AUTH_DOMAIN,
     DRIVING_INTERVAL,
     DOMAIN_KEY,
@@ -49,18 +50,26 @@ class Connection:
         authorization_token: Text = None,
         expiration: int = 0,
         auth_domain: str = AUTH_DOMAIN,
+        client_id: str = CLIENT_ID,
+        api_proxy_url: str = None,
     ) -> None:
         """Initialize connection object."""
         self.user_agent: Text = "TeslaApp/4.10.0"
-        self.client_id: Text = (
-            "81527cff06843c8634fdc09e8ac0abef" "b46ac849f38fe1e431c2ef2106796384"
-        )
-        self.client_secret: Text = (
-            "c7257eb71a564034f9419ee651c7d0e5f7" "aa6bfbd18bafb5c5c033b093bb2fa3"
-        )
-        self.baseurl: Text = DOMAIN_KEY.get(
-            auth_domain[auth_domain.rfind(".") :], API_URL
-        )
+        if client_id == "ownerapi":
+            self.client_id: Text = (
+                "81527cff06843c8634fdc09e8ac0abef" "b46ac849f38fe1e431c2ef2106796384"
+            )
+            self.client_secret: Text = (
+                "c7257eb71a564034f9419ee651c7d0e5f7" "aa6bfbd18bafb5c5c033b093bb2fa3"
+            )
+        else:
+            self.client_id = client_id
+        if api_proxy_url is None:
+            self.baseurl: Text = DOMAIN_KEY.get(
+                auth_domain[auth_domain.rfind(".") :], API_URL
+            )
+        else:
+            self.baseurl: Text = api_proxy_url
         self.websocket_url: Text = WS_URL
         self.api: Text = "/api/1/"
         self.expiration: int = expiration
@@ -563,7 +572,7 @@ class Connection:
             return
         _LOGGER.debug("Refreshing access token with refresh_token")
         oauth = {
-            "client_id": "ownerapi",
+            "client_id": self.client_id,
             "grant_type": "refresh_token",
             "refresh_token": refresh_token,
             "scope": "openid email offline_access",

--- a/teslajsonpy/const.py
+++ b/teslajsonpy/const.py
@@ -17,6 +17,7 @@ MAX_API_RETRY_TIME = 15  # how long to retry api calls
 RELEASE_NOTES_URL = "https://teslascope.com/teslapedia/software/"
 AUTH_DOMAIN = "https://auth.tesla.com"
 API_URL = "https://owner-api.teslamotors.com"
+CLIENT_ID = "ownerapi"
 API_URL_CN = "https://owner-api.vn.cloud.tesla.cn"
 DOMAIN_KEY = {".com": API_URL, ".cn": API_URL_CN}
 WS_URL = "wss://streaming.vn.teslamotors.com/streaming"


### PR DESCRIPTION
This is my first attempt at supporting an external HTTP Proxy, based on Tesla's documentation.  It's working for me on a 2021 Model 3, in conjunction with the [Tesla HTTP Proxy add-on](https://github.com/llamafilm/tesla-http-proxy-addon).

The new Fleet API uses `VIN` for all commands instead of `ID`.  The wording [here](https://github.com/teslamotors/vehicle-command) implies that this should work for older vehicles too, but I need someone else to test if this works on older vehicles.

New optional parameters:
- **client_id** is required by the new API.  I don't understand why this library previously had `client_id` and `client_secret` hardcoded but I left that part as-is if this config field is blank.
- **api_proxy_url** should point to an HTTPS domain
- **api_proxy_cert** if using a self-signed SSL certificate for this, you can provide the path to the certificate here so it will be trusted

Closes #452.