### PR TITLE
fix: maximize chance of reusing the connection while updating

### DIFF
--- a/teslajsonpy/controller.py
+++ b/teslajsonpy/controller.py
@@ -818,7 +818,7 @@ class Controller:
                 # Update in sequence since establishing a new connection
                 # is more expensive because of TLS than the actual update
                 # so we want to maximize the chance of reusing the connection
-                result |= await task
+                result |= bool(await task)
 
             return result
 

--- a/teslajsonpy/controller.py
+++ b/teslajsonpy/controller.py
@@ -813,7 +813,14 @@ class Controller:
                     if energysite[RESOURCE_TYPE] == RESOURCE_TYPE_BATTERY:
                         tasks.append(_get_and_process_site_summary(energysite_id))
 
-            return any(await asyncio.gather(*tasks))
+            result = False
+            for task in tasks:
+                # Update in sequence since establishing a new connection
+                # is more expensive because of TLS than the actual update
+                # so we want to maximize the chance of reusing the connection
+                result |= await task
+
+            return result
 
     def get_updates(self, car_id: Text = None, vin: Text = None):
         """Get updates dictionary.


### PR DESCRIPTION
Previously we would gather which would open a flood of connections and since the cost of establishing the TLS connection `do_handshake` was higher than the actual request, it would take more wall clock time to update and was more resource intensive.