### PR TITLE
fix: fix grid_status

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -23,3 +23,4 @@
 -   craigrouse [Github](https://github.com/craigrouse)
 -   thierryVT [Github](https://github.com/thierryvt)
 -   llamafilm [Github](https://github.com/llamafilm)
+-   ericdegroot [Github](https://github.com/ericdegroot)

--- a/teslajsonpy/energy.py
+++ b/teslajsonpy/energy.py
@@ -159,7 +159,7 @@ class PowerwallSite(EnergySite):
     @property
     def grid_status(self) -> str:
         """Return grid status."""
-        return self._site_summary.get("grid_status")
+        return self._site_data.get("grid_status")
 
     @property
     def load_power(self) -> float:

--- a/tests/unit_tests/test_energy.py
+++ b/tests/unit_tests/test_energy.py
@@ -93,6 +93,10 @@ async def test_powerwall_site(monkeypatch):
         == SITE_DATA["grid_power"]
     )
     assert (
+        _solar_powerwall_site.grid_status
+        == SITE_DATA["grid_status"]
+    )
+    assert (
         _solar_powerwall_site.load_power
         == SITE_DATA["load_power"]
     )


### PR DESCRIPTION
I recently had a Powerwall 3 installed, and I have no local API access. I'm using [Tesla Custom Integration](https://github.com/alandtse/tesla) to integrate the battery into my Home Assistant setup via the owner cloud. The grid status binary sensor provided by that integration always inaccurately showed as 'Clear' or `off`. I traced this back to the `PowerwallSite.grid_status` property in this project. Changing this property to lookup the value in `self._site_data` instead of `self._site_summary` fixed the issue for me. Your test mock data suggests that site data was always the correct source, but I do not have access to any other powerwalls to see if this is unique to Powerwall 3 cloud access.

