### PR TITLE
fix: json attribute error for GET with parameters

### DIFF
--- a/teslajsonpy/connection.py
+++ b/teslajsonpy/connection.py
@@ -200,9 +200,14 @@ class Connection:
 
         try:
             if data:
-                resp: httpx.Response = await getattr(self.websession, method)(
-                    str(url), json=data, headers=headers, cookies=cookies
-                )
+                if method == "get":
+                    resp: httpx.Response = await getattr(self.websession, method)(
+                        str(url), params=data, headers=headers, cookies=cookies
+                    )
+                else:
+                    resp: httpx.Response = await getattr(self.websession, method)(
+                        str(url), json=data, headers=headers, cookies=cookies
+                    )
             else:
                 resp: httpx.Response = await getattr(self.websession, method)(
                     str(url), headers=headers, cookies=cookies


### PR DESCRIPTION
When doing an API call for which the method is get but where parameters are provided an exception occurs for unknown attribute json=data.
This is due to the  httpx get method not supporting the json parameter, instead the params parameter has to be provided.

This fixed checks if the method is get and if it is will provide the additional parameters through params parameter instead.