### PR TITLE
fix: UnboundLocalError when both websession and api_proxy_cert provided

### DIFF
--- a/teslajsonpy/controller.py
+++ b/teslajsonpy/controller.py
@@ -140,14 +140,14 @@ class Controller:
             ssl_context = ssl.create_default_context()
             websession = httpx.AsyncClient(timeout=60, verify=ssl_context)
 
-        if api_proxy_cert:
-            # Loading custom SSL certificate for proxy does blocking I/O.
-            # It is recommended to instead pass an httpx.AsyncClient that
-            # already has an SSL context with the custom certificate loaded.
-            try:
-                ssl_context.load_verify_locations(api_proxy_cert)
-            except (FileNotFoundError, ssl.SSLError):
-                _LOGGER.warning("Unable to load custom SSL certificate from %s", api_proxy_cert)
+            if api_proxy_cert:
+                # Loading custom SSL certificate for proxy does blocking I/O.
+                # It is recommended to instead pass an httpx.AsyncClient that
+                # already has an SSL context with the custom certificate loaded.
+                try:
+                    ssl_context.load_verify_locations(api_proxy_cert)
+                except (FileNotFoundError, ssl.SSLError):
+                    _LOGGER.warning("Unable to load custom SSL certificate from %s", api_proxy_cert)
 
         self.__connection = Connection(
             websession=websession,


### PR DESCRIPTION
Fix for when both websession and api_proxy_cert are provided.