### PR TITLE
fix: Improve testing of result and adjust for Tesla API change

### DIFF
--- a/teslajsonpy/energy.py
+++ b/teslajsonpy/energy.py
@@ -203,7 +203,7 @@ class PowerwallSite(EnergySite):
             path_vars={"site_id": self.energysite_id},
             default_real_mode=real_mode,
         )
-        if data and data["response"]["code"] == 201:
+        if data and data["response"] and data["response"]["Code"] and (len(str(data["response"]["Code"])) == 3) and (str(data["response"]["Code"])[:1] == "2"):
             self._site_config.update({"operation": real_mode})
 
     async def set_reserve_percent(self, value: int) -> None:
@@ -216,7 +216,7 @@ class PowerwallSite(EnergySite):
             path_vars={"site_id": self.energysite_id},
             backup_reserve_percent=int(value),
         )
-        if data and data["response"]["code"] == 201:
+        if data and data["response"] and data["response"]["Code"] and (len(str(data["response"]["Code"])) == 3) and (str(data["response"]["Code"])[:1] == "2"):
             self._site_config.update({"backup_reserve_percent": value})
 
 


### PR DESCRIPTION
Existing test can return incorrect result (fail instead of pass) when HTTP status code is e.g. 200 or some other '2xx' value (all indicate 'okay'). Tesla API has been changed so that (a) result code is now almost always '200' and the 'code' element in the response has changed to 'Code'. Don't ask me why.