### PR TITLE
fix: set default value for percentage_charged

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -26,3 +26,4 @@
 -   ericdegroot [Github](https://github.com/ericdegroot)
 -   flaviorighi [Github](https://github.com/flaviorighi)
 -   djbadders [Github](https://github.com/djbadders)
+-   ericdegroot [Github](https://github.com/ericdegroot)

--- a/teslajsonpy/energy.py
+++ b/teslajsonpy/energy.py
@@ -175,7 +175,7 @@ class PowerwallSite(EnergySite):
     def percentage_charged(self) -> float:
         """Return battery percentage charged."""
         # percentage_charged sometimes incorrectly reports 0
-        return self._site_summary.get("percentage_charged")
+        return self._site_summary.get("percentage_charged", 0)
 
     @property
     def site_name(self) -> str:


### PR DESCRIPTION
Tesla replaced my Powerwall 3 recently. When this happens, the old powerwall product stays in your account for historical data reasons, etc. This has been causing errors with teslajsonpy because the `site_summary` for the old `PowerwallSite` does not include the `percentage_charged` key for whatever reason.

Here's my old Powerwall:

```python
_site_data=None
_site_summary={'resource_type': 'battery', 'site_name': 'My Home Old', 'gateway_id': '*******-**-*--**************', 'battery_type': 'ac_powerwall', 'battery_power': 0, 'go_off_grid_test_banner_enabled': None, 'storm_mode_enabled': False, 'powerwall_onboarding_settings_set': True, 'powerwall_tesla_electric_interested_in': None, 'vpp_tour_enabled': None}
```

And the replacement:

```python
_site_data={'solar_power': 0, 'percentage_charged': 68.2017543859649, 'battery_power': 3131, 'load_power': 3131, 'grid_status': 'Active', 'grid_power': 0, 'generator_power': 0, 'wall_connectors': [], 'island_status': 'on_grid', 'storm_mode_active': False, 'timestamp': '2025-08-07T20:30:07-07:00'}
_site_summary={'resource_type': 'battery', 'site_name': 'My Home', 'gateway_id': '*******-**-*--**************', 'percentage_charged': 68.2017543859649, 'battery_type': 'ac_powerwall', 'battery_power': 3131, 'go_off_grid_test_banner_enabled': None, 'storm_mode_enabled': False, 'powerwall_onboarding_settings_set': True, 'powerwall_tesla_electric_interested_in': None, 'vpp_tour_enabled': None}
```