### PR TITLE
fix: Add default value to nameplate_energy get

### DIFF
--- a/teslajsonpy/energy.py
+++ b/teslajsonpy/energy.py
@@ -149,7 +149,7 @@ class PowerwallSite(EnergySite):
     @property
     def energy_left(self) -> float:
         """Return battery energy left in Watt hours."""
-        return round(self._site_config.get("nameplate_energy") * self.percentage_charged / 100)
+        return round(self._site_config.get("nameplate_energy", 0) * self.percentage_charged / 100)
 
     @property
     def grid_power(self) -> float:


### PR DESCRIPTION
I found another issue related to my replaced Powerwall 3. The `_site_config` for the old powerwall does not include a `nameplate_energy` key. For my new powerwall, this entry has a value of 0, but the key is at least part of the payload. I added a default value to this one also.

Here's the stack trace from HA:

```text
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 1002, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1382, in add_to_platform_finish
    self.async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1026, in async_write_ha_state
    self._async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1151, in _async_write_ha_state
    self.__async_calculate_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1088, in __async_calculate_state
    state = self._stringify_state(available)
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1032, in _stringify_state
    if (state := self.state) is None:
                 ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 548, in state
    value = self.native_value
            ^^^^^^^^^^^^^^^^^
  File "/config/custom_components/tesla_custom/sensor.py", line 444, in native_value
    return round(self._energysite.energy_left or 0)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/teslajsonpy/energy.py", line 152, in energy_left
    return round(self._site_config.get("nameplate_energy") * self.percentage_charged / 100)
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'
```