### PR TITLE
chore: release 2026-07-28

### DIFF
--- a/.github/workflows/test_and_lint.yaml
+++ b/.github/workflows/test_and_lint.yaml
@@ -31,6 +31,7 @@ jobs:
     - name: Install Poetry
       uses: snok/install-poetry@v1
       with:
+        version: "2.2.1"
         virtualenvs-create: true
         virtualenvs-in-project: true
     #----------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.8.5; python_version >= "3.6"
+aiohttp==3.9.0; python_version >= "3.6"
 aiosignal==1.2.0; python_version >= "3.7" and python_version < "4.0"
 alabaster==0.7.12; python_version >= "3.7"
 anyio==3.6.2; python_version >= "3.7" and python_version < "4.0" and python_full_version >= "3.6.2"

--- a/teslajsonpy/controller.py
+++ b/teslajsonpy/controller.py
@@ -359,9 +359,20 @@ class Controller:
 
     async def get_site_data(self, energysite_id: int) -> dict:
         """Get site data json from TeslaAPI for a given energysite_id."""
-        return (await self.api("SITE_DATA", path_vars={"site_id": energysite_id}))[
+        response = (await self.api("SITE_DATA", path_vars={"site_id": energysite_id}))[
             "response"
         ]
+        if not isinstance(response, dict):
+            # Some energy sites answer HTTP 200 with a bare string instead of an
+            # object. That is not a TeslaException, so it would otherwise be stored
+            # as-is and later crash on .get()/.update().
+            _LOGGER.warning(
+                "Unexpected SITE_DATA response for energysite %s, ignoring: %r",
+                energysite_id,
+                response,
+            )
+            return {}
+        return response
 
     async def get_site_summary(self, energysite_id: int) -> dict:
         """Get site data json from TeslaAPI for a given energysite_id."""

--- a/teslajsonpy/energy.py
+++ b/teslajsonpy/energy.py
@@ -6,7 +6,7 @@ For more details about this api, please refer to the documentation at
 https://github.com/zabuldon/teslajsonpy
 """
 import logging
-from typing import Callable
+from typing import Callable, Optional
 
 from teslajsonpy.const import DEFAULT_ENERGYSITE_NAME, RESOURCE_TYPE
 
@@ -147,9 +147,12 @@ class PowerwallSite(EnergySite):
         return self._site_summary != {}
 
     @property
-    def energy_left(self) -> float:
+    def energy_left(self) -> Optional[float]:
         """Return battery energy left in Watt hours."""
-        return round(self._site_config.get("nameplate_energy", 0) * self.percentage_charged / 100)
+        value = self._site_config.get("nameplate_energy")
+        if value is None:
+            return None
+        return round(value * self.percentage_charged / 100)
 
     @property
     def grid_power(self) -> float:
@@ -172,10 +175,10 @@ class PowerwallSite(EnergySite):
         return self._site_config.get("default_real_mode")
 
     @property
-    def percentage_charged(self) -> float:
+    def percentage_charged(self) -> Optional[float]:
         """Return battery percentage charged."""
         # percentage_charged sometimes incorrectly reports 0
-        return self._site_summary.get("percentage_charged", 0)
+        return self._site_summary.get("percentage_charged")
 
     @property
     def site_name(self) -> str:

--- a/tests/unit_tests/test_energy.py
+++ b/tests/unit_tests/test_energy.py
@@ -171,3 +171,31 @@ async def test_set_export_rule(monkeypatch):
 
 
 # Test reponse with "grid_status" of "Unknown"
+
+
+@pytest.mark.asyncio
+async def test_get_site_data_with_non_dict_response(monkeypatch):
+    """Test SITE_DATA returning a bare string instead of an object."""
+
+    async def mock_api(self, name, *args, **kwargs):
+        # pylint: disable=unused-argument
+        return {"response": "site_unavailable"}
+
+    monkeypatch.setattr(Controller, "api", mock_api)
+    _controller = Controller(None)
+
+    assert await _controller.get_site_data(12345) == {}
+
+
+@pytest.mark.asyncio
+async def test_solar_site_with_empty_site_data(monkeypatch):
+    """Test SolarSite reports no data rather than raising when site data is empty."""
+    _mock = TeslaMock(monkeypatch)
+    _api = _mock.controller_api
+    _energysite = ENERGYSITES[0]
+    _site_config = SITE_CONFIG
+
+    _solar_site = SolarSite(_api, _energysite, _site_config, {})
+
+    assert _solar_site.data_available is False
+    assert _solar_site.solar_power is None


### PR DESCRIPTION
* Updated powerwall site grid_status property to using site data instead of summary

* Added default value to nameplate_energy get

* Updated PowerwallSite.energy_left() to return None if key not present

* Removed PowerwallSite.percentage_charged default to 0 when key not present