### PR TITLE
fix: don't assume the SITE_DATA response is a dict

### DIFF
--- a/teslajsonpy/controller.py
+++ b/teslajsonpy/controller.py
@@ -359,9 +359,20 @@ class Controller:
 
     async def get_site_data(self, energysite_id: int) -> dict:
         """Get site data json from TeslaAPI for a given energysite_id."""
-        return (await self.api("SITE_DATA", path_vars={"site_id": energysite_id}))[
+        response = (await self.api("SITE_DATA", path_vars={"site_id": energysite_id}))[
             "response"
         ]
+        if not isinstance(response, dict):
+            # Some energy sites answer HTTP 200 with a bare string instead of an
+            # object. That is not a TeslaException, so it would otherwise be stored
+            # as-is and later crash on .get()/.update().
+            _LOGGER.warning(
+                "Unexpected SITE_DATA response for energysite %s, ignoring: %r",
+                energysite_id,
+                response,
+            )
+            return {}
+        return response
 
     async def get_site_summary(self, energysite_id: int) -> dict:
         """Get site data json from TeslaAPI for a given energysite_id."""

--- a/tests/unit_tests/test_energy.py
+++ b/tests/unit_tests/test_energy.py
@@ -171,3 +171,31 @@ async def test_set_export_rule(monkeypatch):
 
 
 # Test reponse with "grid_status" of "Unknown"
+
+
+@pytest.mark.asyncio
+async def test_get_site_data_with_non_dict_response(monkeypatch):
+    """Test SITE_DATA returning a bare string instead of an object."""
+
+    async def mock_api(self, name, *args, **kwargs):
+        # pylint: disable=unused-argument
+        return {"response": "site_unavailable"}
+
+    monkeypatch.setattr(Controller, "api", mock_api)
+    _controller = Controller(None)
+
+    assert await _controller.get_site_data(12345) == {}
+
+
+@pytest.mark.asyncio
+async def test_solar_site_with_empty_site_data(monkeypatch):
+    """Test SolarSite reports no data rather than raising when site data is empty."""
+    _mock = TeslaMock(monkeypatch)
+    _api = _mock.controller_api
+    _energysite = ENERGYSITES[0]
+    _site_config = SITE_CONFIG
+
+    _solar_site = SolarSite(_api, _energysite, _site_config, {})
+
+    assert _solar_site.data_available is False
+    assert _solar_site.solar_power is None


### PR DESCRIPTION
`get_site_data()` returns `["response"]` straight from the API, and `connection.py` only raises `TeslaException` for `status_code > 299` or a body with an `error` key. An energy site that answers HTTP 200 with `"response"` as a bare string therefore flows through untouched, and `_site_data[energysite_id]` becomes a `str`.

Downstream that shows up as:

- `SolarSite.data_available` is `self._site_data != {}`, and a non-empty string passes, so the site looks like it has data;
- `solar_power` / `grid_power` / `load_power` then hit `'str' object has no attribute 'get'`;
- on the next poll `_get_and_process_site_data` hits `'str' object has no attribute 'update'` — alandtse/tesla#494, open since 2023.

Recent report with a full traceback: https://github.com/alandtse/tesla/discussions/1231 (a leased SolarCity site; the owned site on the same account is fine).

This returns `{}` and logs a warning when the payload isn't a dict, so `data_available` correctly reports `False` and the site is skipped instead of half-created.

Scoped deliberately to `get_site_data`, since that is the path with a confirmed report. `get_site_config` and `get_site_summary` have the same shape and could get the same guard if you'd like it here.

Added a test that reproduces it — it fails on `dev` with `assert 'site_unavailable' == {}` and passes with the fix. Full suite: 74 passed.