### PR TITLE
ci: pin Poetry to 2.2.1

### DIFF
--- a/.github/workflows/test_and_lint.yaml
+++ b/.github/workflows/test_and_lint.yaml
@@ -31,6 +31,7 @@ jobs:
     - name: Install Poetry
       uses: snok/install-poetry@v1
       with:
+        version: "2.2.1"
         virtualenvs-create: true
         virtualenvs-in-project: true
     #----------------------------------------------


### PR DESCRIPTION
`build (3.9)` has been failing at the `Install Poetry` step, so Black, Lint and pytest never run on 3.9.

`snok/install-poetry` installs the latest Poetry, and Poetry raised `requires_python` to `>=3.10` in 2.3.0. Pinning to 2.2.1, the last release that still supports 3.9.

If you'd rather drop 3.9 from the matrix instead, happy to switch.
